### PR TITLE
Add option for changing windows icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ nw.build().then(function () {
 });
 
 // And supports callbacks
-nw.build(funtion(err) {
+nw.build(function(err) {
     if(err) console.log(err);
 })
 
@@ -149,6 +149,12 @@ Type: `String`
 Default value: `false`  
 
 MAC ONLY: if you supply a string to a Plist file it will use it. Otherwise it will generate something usefull from your package.json
+
+#### options.winIco
+Type: `String`  
+Default value: `null`  
+
+WINDOWS ONLY: The path to your ICO icon file. If your don't provide your own it will use the one provided by node-webkit
 
 
 ## To Do:

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,6 +5,7 @@ var EventEmitter = require('events').EventEmitter;
 var fs = require('fs-extra');
 var path = require('path');
 var url = require('url');
+var rcedit = Promise.promisify(require("rcedit"));
 
 var NwVersions = require('./versions');
 var Utils = require('./utils');
@@ -31,25 +32,26 @@ function NwBuilder(options) {
         macCredits: false,
         macIcns: false,
         macZip: false,
-        macPlist: false
+        macPlist: false,
+        winIco: null
     };
 
     // Assing options
     this.options = _.defaults(options, defaults);
     this._platforms = [{
-        plattform: 'win',
+        platform: 'win',
         needsZip: true,
         files: ['nw.exe', 'ffmpegsumo.dll', 'icudt.dll', 'libEGL.dll', 'libGLESv2.dll', 'nw.pak'] // First file must be the executable
     },{
-        plattform: 'osx',
+        platform: 'osx',
         files: ['node-webkit.app']
     },{
-        plattform: 'linux32',
+        platform: 'linux32',
         needsZip: true,
         chmod: '0755',
         files: ['nw', 'nw.pak', 'libffmpegsumo.so'] // First file must be the executable
     },{
-        plattform: 'linux64',
+        platform: 'linux64',
         needsZip: true,
         chmod: '0755', // chmod file file to be executable
         files: ['nw', 'nw.pak', 'libffmpegsumo.so'] // First file must be the executable
@@ -60,12 +62,12 @@ function NwBuilder(options) {
         throw new Error('Please specify some files');
     }
 
-    // Check platforms
-    this._platforms.forEach(function (plattform) {
-        plattform.active = (self.options.platforms.indexOf(plattform.plattform) === -1 ? false : true);
-    });
 
-    // platforms
+    // Check Platforms
+    this._platforms.forEach(function (platform) {
+        platform.active = (self.options.platforms.indexOf(platform.platform) === -1 ? false : true);
+    });
+    // Platforms
     this._platforms = _.where(this._platforms, {'active':true});
 
     if(this._platforms.length === 0 || this._platforms.length === undefined) {
@@ -88,6 +90,7 @@ NwBuilder.prototype.build = function (callback) {
         .then(this.zipAppFiles)
         .then(this.mergeAppFiles)
         .then(this.handleMacApp)
+        .then(this.handleWinApp)
         .then(function (info) {
             if(hasCallback) {
                 callback(false, info);
@@ -155,26 +158,26 @@ NwBuilder.prototype.downloadNodeWebkit = function () {
     var self = this,
         downloads = [];
 
-    this._platforms.map(function (single_plattform) {
-        single_plattform.cache = path.resolve(self.options.cacheDir, self._version.version, single_plattform.plattform);
-        single_plattform.url = url.resolve(self.options.downloadUrl, self._version.platforms[single_plattform.plattform]);
+    this._platforms.map(function (single_platform) {
+        single_platform.cache = path.resolve(self.options.cacheDir, self._version.version, single_platform.platform);
+        single_platform.url = url.resolve(self.options.downloadUrl, self._version.platforms[single_platform.platform]);
 
         // Ensure that there is a cache folder
         if(self.options.forceDownload) {
-            fs.removeSync(single_plattform.cache);
+            fs.removeSync(single_platform.cache);
         }
 
-        fs.mkdirpSync(single_plattform.cache);
+        fs.mkdirpSync(single_platform.cache);
         self.emit('log', 'Create cache folder in ' + path.resolve(self.options.cacheDir, self._version.version));
 
-        if(!Downloader.checkCache(single_plattform.cache, single_plattform.files)) {
-            downloads.push(Downloader.downloadAndUnpack(single_plattform.cache, single_plattform.url));
-            self.emit('log', 'Downloading: ' + single_plattform.url);
+        if(!Downloader.checkCache(single_platform.cache, single_platform.files)) {
+            downloads.push(Downloader.downloadAndUnpack(single_platform.cache, single_platform.url));
+            self.emit('log', 'Downloading: ' + single_platform.url);
         } else {
-            self.emit('log', 'Using cache for: ' + single_plattform.plattform);
+            self.emit('log', 'Using cache for: ' + single_platform.platform);
         }
 
-        return single_plattform;
+        return single_platform;
     });
 
     return Promise.all(downloads);
@@ -212,13 +215,13 @@ NwBuilder.prototype.createReleaseFolder = function () {
     }
 
 
-    this._platforms.forEach(function (single_plattform) {
-        single_plattform.releasePath = path.resolve(self.options.buildDir, releasePath, single_plattform.plattform);
+    this._platforms.forEach(function (single_platform) {
+        single_platform.releasePath = path.resolve(self.options.buildDir, releasePath, single_platform.platform);
 
         // Ensure that there is a release Folder, delete and create it.
-        fs.removeSync(single_plattform.releasePath);
-        fs.mkdirpSync(single_plattform.releasePath);
-        self.emit('log', 'Create release folder in ' + single_plattform.releasePath);
+        fs.removeSync(single_platform.releasePath);
+        fs.mkdirpSync(single_platform.releasePath);
+        self.emit('log', 'Create release folder in ' + single_platform.releasePath);
     });
 
     return true;
@@ -228,9 +231,9 @@ NwBuilder.prototype.createReleaseFolder = function () {
 NwBuilder.prototype.copyNodeWebkit = function () {
     var copiedFiles = [];
 
-    this._platforms.forEach(function (single_plattform) {
-        single_plattform.files.forEach(function (file) {
-            copiedFiles.push(Utils.copyFile(path.resolve(single_plattform.cache, file), path.resolve(single_plattform.releasePath, file)));
+    this._platforms.forEach(function (single_platform) {
+        single_platform.files.forEach(function (file) {
+            copiedFiles.push(Utils.copyFile(path.resolve(single_platform.cache, file), path.resolve(single_platform.releasePath, file)));
         });
     });
 
@@ -260,22 +263,22 @@ NwBuilder.prototype.mergeAppFiles = function () {
     var self = this,
         copiedFiles = [];
 
-    this._platforms.forEach(function (single_plattform) {
+    this._platforms.forEach(function (single_platform) {
         // We copy the app files if we are on mac and don't force zip
-        if(single_plattform.plattform === 'osx') {
+        if(single_platform.platform === 'osx') {
             // no zip, copy the files
             if(!self.options.macZip) {
                 self._files.forEach(function (file) {
-                    var dest = path.resolve(single_plattform.releasePath, 'node-webkit.app', 'Contents', 'Resources', 'app.nw', file.dest);
+                    var dest = path.resolve(single_platform.releasePath, 'node-webkit.app', 'Contents', 'Resources', 'app.nw', file.dest);
                     copiedFiles.push(Utils.copyFile(file.src, dest));
                 });
             } else {
                 // zip just copy the app.nw
-                copiedFiles.push(Utils.copyFile(self._nwFile, path.resolve(single_plattform.releasePath, 'node-webkit.app', 'Contents', 'Resources', 'nw.icns')));
+                copiedFiles.push(Utils.copyFile(self._nwFile, path.resolve(single_platform.releasePath, 'node-webkit.app', 'Contents', 'Resources', 'nw.icns')));
             }
         } else {
             // We cat the app.nw file into the .exe / nw
-            copiedFiles.push(Utils.mergeFiles(path.resolve(single_plattform.releasePath, _.first(single_plattform.files)), self._nwFile), single_plattform.chmod);
+            copiedFiles.push(Utils.mergeFiles(path.resolve(single_platform.releasePath, _.first(single_platform.files)), self._nwFile), single_platform.chmod);
         }
     });
 
@@ -284,16 +287,16 @@ NwBuilder.prototype.mergeAppFiles = function () {
 
 NwBuilder.prototype.handleMacApp = function () {
     var self = this, allDone = [];
-    var macPlattform = _.findWhere(self._platforms, {'plattform':'osx'});
-    if(!macPlattform) return Promise.resolve();
+    var macPlatform = _.findWhere(self._platforms, {'platform':'osx'});
+    if(!macPlatform) return Promise.resolve();
 
     // Let's first handle the mac icon
     if(self.options.macIcns) {
-        allDone.push(Utils.copyFile(self.options.macIcns, path.resolve(macPlattform.releasePath, 'node-webkit.app', 'Contents', 'Resources', 'app.icns')));
+        allDone.push(Utils.copyFile(self.options.macIcns, path.resolve(macPlatform.releasePath, 'node-webkit.app', 'Contents', 'Resources', 'app.icns')));
     }
 
     // Let handle the Plist
-    var PlistPath = path.resolve(macPlattform.releasePath, 'node-webkit.app', 'Contents', 'Info.plist');
+    var PlistPath = path.resolve(macPlatform.releasePath, 'node-webkit.app', 'Contents', 'Info.plist');
 
     // If the macPlist is a string we just copy the file
     if(typeof self.options.macPlist === 'String') {
@@ -312,4 +315,23 @@ NwBuilder.prototype.handleMacApp = function () {
 
     return Promise.all(allDone);
 
+};
+
+NwBuilder.prototype.handleWinApp = function () {
+    var self = this, allDone = [];
+    var winPlatform = _.findWhere(self._platforms, {'platform':'win'});
+    if(!winPlatform) return Promise.resolve();
+
+    // Set icon
+    if (self.options.winIco) {
+        self.emit('log', "Update executable icon");
+        allDone.push(rcedit(
+            path.resolve(winPlatform.releasePath, _.first(winPlatform.files)),
+            {
+                icon: path.resolve(self.options.winIco)
+            }
+        ));
+    }
+
+    return Promise.all(allDone);
 };

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "archiver": "~0.8.1",
     "tar-fs": "^0.3.2",
     "optimist": "^0.6.1",
-    "update-notifier": "^0.1.8"
+    "update-notifier": "^0.1.8",
+    "rcedit": "0.2.0"
   }
 }


### PR DESCRIPTION
This PR add an option `winIco` for changing the windows executable icon. This is working, I just test it using:

```
var NwBuilder = require('./');
var nw = new NwBuilder({
    files: '/Users/samypesse/Desktop/Projects/GitBook/editor/**/**', // use the glob format
    platforms: ['win'],
    winIco: '/Users/samypesse/Desktop/Projects/GitBook/editor/src/resources/images/icons/512.ico'
});

// Log stuff you you want
nw.on('log',  console.log);

// Build retruns a promise
nw.build().then(function () {
   console.log('all done!');
}).catch(function (error) {
    console.error(error);
});
```

I also fix a typo: "platform" instead of "plattform".

I have a PR pending on https://github.com/atom/node-rcedit/pull/1 that adds the support of mac and linux to node-rcedit.
