### PR TITLE
Fix incorrect linux arch

### DIFF
--- a/lib/versions.js
+++ b/lib/versions.js
@@ -16,8 +16,8 @@ module.exports = {
                     'platforms': {
                         'win': 'v' + version + '/node-webkit-v' + version + '-win-ia32.zip',
                         'osx': 'v' + version + '/node-webkit-v' + version + '-osx-ia32.zip',
-                        'linux32': 'v' + version + '/node-webkit-v' + version + '-linux-x64.tar.gz',
-                        'linux64': 'v' + version + '/node-webkit-v' + version + '-linux-ia32.tar.gz'
+                        'linux32': 'v' + version + '/node-webkit-v' + version + '-linux-ia32.tar.gz',
+                        'linux64': 'v' + version + '/node-webkit-v' + version + '-linux-x64.tar.gz'
                     }
                 }]);
             }
@@ -32,10 +32,10 @@ module.exports = {
             regex: /v(\d.\d.\d)\/node-webkit-v(?:\d.\d.\d)-osx-ia32\.zip/g
         }, {
             platform: 'linux32',
-            regex: /v(\d.\d.\d)\/node-webkit-v(?:\d.\d.\d)-linux-x64\.tar\.gz/g
+            regex: /v(\d.\d.\d)\/node-webkit-v(?:\d.\d.\d)-linux-ia32\.tar\.gz/g
         }, {
             platform: 'linux64',
-            regex: /v(\d.\d.\d)\/node-webkit-v(?:\d.\d.\d)-linux-ia32\.tar\.gz/g
+            regex: /v(\d.\d.\d)\/node-webkit-v(?:\d.\d.\d)-linux-x64\.tar\.gz/g
         }], versions = {}, sortedVersions = [];
 
         platforms.forEach(function (platform) {


### PR DESCRIPTION
It was building Linux32 when requesting Linux64, and vise versa.

Please publish as a patch of 0.0.2, so we can all benefit from this fix asap.
