### PR TITLE
Fix callback error passing.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -105,7 +105,7 @@ NwBuilder.prototype.build = function (callback) {
         })
         .catch(function (error) {
             if(hasCallback) {
-                callback(true, error);
+                callback(error);
             } else {
                 done.reject(error);
             }


### PR DESCRIPTION
When an error occurs when using a callback, the error argument ends up being set to `true` instead of the actual error message. This pull request fixes that.
