### PR TITLE
Make Icns icons work

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -326,7 +326,7 @@ NwBuilder.prototype.handleMacApp = function () {
 
     // Let's first handle the mac icon
     if(self.options.macIcns) {
-        allDone.push(Utils.copyFile(self.options.macIcns, path.resolve(macPlatform.releasePath, 'node-webkit.app', 'Contents', 'Resources', 'app.icns')));
+        allDone.push(Utils.copyFile(self.options.macIcns, path.resolve(macPlatform.releasePath, 'node-webkit.app', 'Contents', 'Resources', 'nw.icns')));
     }
 
     // Let handle the Plist


### PR DESCRIPTION
The resulting icon needs to be called nw.icns, otherwise there are two icons in the folder.
