### PR TITLE
Add supports for function in buildType

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ nw.build(function(err) {
 
 ### Options
 
-#### options.files *Required* 
+#### options.files *Required*
 Type: `String`  
 Default value: `null`  
 
@@ -112,10 +112,15 @@ Default value: `./cache`
 This is where the cached node-webkit downloads are
 
 #### options.buildType
-Type: `String`  
+Type: `String` or `function`
 Default value: `default`  
 
-How you want to save your build. You can choose from `default` which is `timestamped`. There is also ``versioned`
+How you want to save your build.
+
+* `default` [appName]
+* `versioned` [appName] -v[appVersion]
+* `timestamped` [appName] - [timestamp];
+* A function with options as scope (e.g `function () {return this.appVersion;}` )
 
 #### options.forceDownload
 Type: `Boolean`  

--- a/lib/index.js
+++ b/lib/index.js
@@ -27,7 +27,7 @@ function NwBuilder(options) {
         cacheDir: './cache',
         versionsUrl: 'https://s3.amazonaws.com/node-webkit/',
         downloadUrl: 'http://dl.node-webkit.org/',
-        buildType: 'default', // timestamped
+        buildType: 'default',
         forceDownload: false,
         checkVersions: true,
         macCredits: false,
@@ -230,24 +230,23 @@ NwBuilder.prototype.createReleaseFolder = function () {
     var self = this,
         releasePath;
 
-    // buildTypes
-    switch(self.options.buildType) {
-        case 'timestamped':
-            releasePath = self.options.appName + ' - ' + Math.round(Date.now() / 1000).toString();
-        break;
+    if (_.isFunction(self.options.buildType)) {
+      releasePath = self.options.buildType.call(self.options);
+    } else {
+      // buildTypes
+      switch(self.options.buildType) {
+          case 'timestamped':
+              releasePath = self.options.appName + ' - ' + Math.round(Date.now() / 1000).toString();
+          break;
 
-        case 'versioned':
-            releasePath = self.options.appName + ' - v' + self.options.appVersion;
-        break;
+          case 'versioned':
+              releasePath = self.options.appName + ' - v' + self.options.appVersion;
+          break;
 
-        case 'default':
-            releasePath = self.options.appName;
-        break;
-
-        default:
-            releasePath = self.options.appName;
+          default:
+              releasePath = self.options.appName;
+      }
     }
-
 
     this._platforms.forEach(function (single_platform) {
         single_platform.releasePath = path.resolve(self.options.buildDir, releasePath, single_platform.platform);


### PR DESCRIPTION
Add supports for functions in `buildType`.

`buildType: function () {return this.appVersion;}`

I haven't found test for buildType and since it's kinda trivial I didn't wrote any.
