### PR TITLE
Use promises in Gulp example

### DIFF
--- a/example/Gulpfile.js
+++ b/example/Gulpfile.js
@@ -2,7 +2,7 @@ var NwBuilder = require('node-webkit-builder');
 var gulp = require('gulp');
 var gutil = require('gulp-util');
 
-gulp.task('nw', function (callback) {
+gulp.task('nw', function () {
 
     var nw = new NwBuilder({
         version: '0.9.2',
@@ -10,16 +10,12 @@ gulp.task('nw', function (callback) {
     });
 
     // Log stuff you want
-    nw.on('log', function (mgs) {
-        gutil.log('node-webkit-builder', mgs);
+    nw.on('log', function (msg) {
+        gutil.log('node-webkit-builder', msg);
     });
 
-    // Build retruns a promise
-    nw.build(function (err) {
-        if(err) {
-            gutil.log('node-webkit-builder', err);
-        }
-        callback();
-        gutil.beep();
+    // Build returns a promise, return it so the task isn't called in parallel
+    return nw.build().catch(function (err) {
+        gutil.log('node-webkit-builder', err);
     });
 });


### PR DESCRIPTION
Gulp supports returning promises to make the task not parallel, so just return it, and use promise-like functions for error logging.
Also, fix a couple typos.
