### PR TITLE
Fixed more versioning issues

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -25,7 +25,6 @@ function NwBuilder(options) {
         version: 'lastest',
         buildDir: './build',
         cacheDir: './cache',
-        versionsUrl: 'https://s3.amazonaws.com/node-webkit/',
         downloadUrl: 'http://dl.node-webkit.org/',
         buildType: 'default',
         forceDownload: false,
@@ -170,7 +169,7 @@ NwBuilder.prototype.checkVersions = function (versions) {
     if(!self.options.checkVersions) {
         version = NwVersions.getVersionNames(self.options.version);
     } else {
-        version = NwVersions.getVersions(this.options.versionsUrl);
+        version = NwVersions.getVersions();
     }
 
     return NwVersions.getLatestVersion().then(function(latestVersion) {

--- a/lib/versions.js
+++ b/lib/versions.js
@@ -1,28 +1,42 @@
 var Promise = require('bluebird');
-var npm = Promise.promisify(require('npm'));
+var npm = Promise.promisifyAll(require('npm'));
+var semver = require('semver');
 
-function getNpmInfo(prop) {
+function getNPMVersions() {
     return npm.loadAsync()
         .then(function() {
-            return Promise.promisify(npm.commands.info)(['nodewebkit', prop], true);
+            return Promise.promisify(npm.commands.info)(['nodewebkit', 'versions'], true);
         });
+}
+
+function filterVersions(data) {
+    // filter out patch/build versions
+    var versions = data[Object.keys(data)[0]].versions.filter(function(version) {
+        return !/\-/.test(version);
+    });
+    // sort highest to lowest
+    versions.sort(function(a, b) {
+        return semver.lt(a, b);
+    });
+    return versions;
 }
 
 module.exports = {
     getLatestVersion: function() {
-        return getNpmInfo('version')
-            .then(function(info) {
-                return Object.keys(info)[0];
+        return getNPMVersions()
+            .then(filterVersions)
+            .then(function(versions) {
+                return versions[0];
             });
     },
     getVersions: function () {
-        return getNpmInfo('versions')
-            .then(function(info) {
-                return info[Object.keys(info)[0]].versions;
-            })
+        return getNPMVersions()
+            .then(filterVersions)
             .then(this.getVersionNames);
     },
     getVersionNames: function (version) {
+        // The nodewebkit npm package tracks the version of node-webkit, which is why we build
+        // the archive names using the versions from npm.
         return new Promise(function(resolve, reject) {
             if (!version || version === 'latest') {
                 reject('You need to specify a version (eg 0.8.4) if you disable checkVersions');

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   "homepage": "https://github.com/mllrsohn/node-webkit-builder",
   "devDependencies": {
     "nock": "^0.32.3",
-    "semver": "^2.3.1",
     "tape": "^2.12.3"
   },
   "dependencies": {
@@ -41,6 +40,7 @@
     "tar-fs": "^0.3.2",
     "optimist": "^0.6.1",
     "update-notifier": "^0.1.8",
-    "rcedit": "0.2.0"
+    "rcedit": "0.2.0",
+    "semver": "^2.3.1"
   }
 }


### PR DESCRIPTION
Although the nodewebkit npm package tracks the same versions as node-webkit, it can also have patch/build versions which we need to filter out.

Running apps in node-webkit is now working on linux, I need to do more testing with building, but at least now it's downloadng the correct node-webkit version :+1: 

I now understand why this bit of code existed: https://github.com/mllrsohn/node-webkit-builder/blob/2ea258caf6e54a5f0f4ecaf8e21cc73cbc5114de/lib/versions.js#L17
