### PR TITLE
add npm as deps needed since PR #26

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "tar-fs": "^0.3.2",
     "optimist": "^0.6.1",
     "update-notifier": "^0.1.8",
-    "rcedit": "0.2.0"
+    "rcedit": "0.2.0",
+    "npm": "^1.4.20"
   }
 }


### PR DESCRIPTION
As it was discussed in mllrsohn/node-webkit-builder#26 npm should be declared as local dependency.
