### PR TITLE
node-webkit 0.10.0 version fix also on run

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -123,6 +123,7 @@ NwBuilder.prototype.run = function (callback) {
     // Let's create a node Webkit app
     this.checkFiles().bind(this)
         .then(this.checkVersions)
+        .then(this.platformFilesForVersion)
         .then(this.downloadNodeWebkit)
         .then(this.runApp)
         .then(function (info) {


### PR DESCRIPTION
On windows, nwbuild -r source_folder will ignore cached node-webkit
