### PR TITLE
Windows builds failing

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -406,7 +406,7 @@ NwBuilder.prototype.handleWinApp = function () {
     var self = this,
         done = Promise.defer();
     var winPlatform = _.findWhere(self._platforms, {'platform':'win'});
-    if(!winPlatform) return Promise.resolve();
+    if(!winPlatform || !self.options.winIco) return Promise.resolve();
 
     // Set icon
     if (self.options.winIco) {


### PR DESCRIPTION
Hi,
here is a fix for the windows builds.
The promise never resolved if the `winIco` option is set to `false`.
