### PR TITLE
resolves mllrsohn/grunt-node-webkit-builder#100

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -428,6 +428,9 @@ NwBuilder.prototype.handleWinApp = function () {
             }
         );
     }
+    else {
+        return done.resolve();
+    }
 
     return done.promise;
 };


### PR DESCRIPTION
resolves mllrsohn/grunt-node-webkit-builder#100
- need to resolve promise in `handleWinApp()` if no icon option set
