### PR TITLE
Fixed windows icon replacement by changing the build order

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -104,10 +104,10 @@ NwBuilder.prototype.build = function (callback) {
         .then(this.downloadNodeWebkit)
         .then(this.createReleaseFolder)
         .then(this.copyNodeWebkit)
-        .then(this.zipAppFiles)
-        .then(this.mergeAppFiles)
         .then(this.handleMacApp)
         .then(this.handleWinApp)
+        .then(this.zipAppFiles)
+        .then(this.mergeAppFiles)
         .then(function (info) {
             if(hasCallback) {
                 callback(false, info);


### PR DESCRIPTION
As already described in issue #44, I was having some build issues on windows with the switch over to resourcer. For some reason (I still haven't figured it out why) resourcer removes the appended app content of the exe file, which results in a blank node-webkit application after replacing the windows icon. The simple solution for me was changing the build order, so that the app content gets appended afterwards.
