### PR TITLE
Fix macCredits option doesn't work

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -383,6 +383,11 @@ NwBuilder.prototype.handleMacApp = function () {
     if(self.options.macIcns) {
         allDone.push(Utils.copyFile(self.options.macIcns, path.resolve(macPlatform.releasePath, self.options.appName+'.app', 'Contents', 'Resources', 'nw.icns')));
     }
+    
+    // Handle mac credits
+    if(self.options.macCredits) {
+        allDone.push(Utils.copyFile(self.options.macCredits, path.resolve(macPlatform.releasePath, self.options.appName+'.app', 'Contents', 'Resources', 'Credits.html')));
+    }
 
     // Let handle the Plist
     var PlistPath = path.resolve(macPlatform.releasePath, self.options.appName+'.app', 'Contents', 'Info.plist');


### PR DESCRIPTION
The `macCredits` option doesn't work for me, so I've tried to find out what's going on and it looks like someone just forgot to handle it.

The fix is simple. I just copied `macIcns` handling and did some renaming.
