### PR TITLE
self-instantiated main class/function

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -19,6 +19,7 @@ var platforms = require('./platforms');
 inherits(NwBuilder, EventEmitter);
 module.exports = NwBuilder;
 function NwBuilder(options) {
+    if (!(this instanceof NwBuilder)) return new NwBuilder(options);
     var self = this;
     var defaults = {
         files: null,


### PR DESCRIPTION
No need to use `new NwBuidler(opts)`, simply `NwBuidler(opts)` will do.
Refers to part of #70 
