### PR TITLE
Copy nw locales

### DIFF
--- a/lib/platforms.js
+++ b/lib/platforms.js
@@ -3,8 +3,8 @@ module.exports = {
         needsZip: true,
         runable: 'nw.exe',
         files: { // First file must be the executable
-            '<=0.9.2': ['nw.exe', 'ffmpegsumo.dll', 'icudt.dll', 'libEGL.dll', 'libGLESv2.dll', 'nw.pak'],
-            '>0.9.2': ['nw.exe', 'ffmpegsumo.dll', 'icudtl.dat', 'libEGL.dll', 'libGLESv2.dll', 'nw.pak']
+            '<=0.9.2': ['nw.exe', 'ffmpegsumo.dll', 'icudt.dll', 'libEGL.dll', 'libGLESv2.dll', 'nw.pak', 'locales'],
+            '>0.9.2': ['nw.exe', 'ffmpegsumo.dll', 'icudtl.dat', 'libEGL.dll', 'libGLESv2.dll', 'nw.pak', 'locales']
         },
         versionNameTemplate: 'v${ version }/node-webkit-v${ version }-win-ia32.zip'
     },


### PR DESCRIPTION
Hi,
This change would fix #88  Without those files, `navigator.language` is empty, at least on windows.
