### PR TITLE
Fixed typo when using macZip true

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -343,7 +343,7 @@ NwBuilder.prototype.mergeAppFiles = function () {
                 });
             } else {
                 // zip just copy the app.nw
-                copiedFiles.push(Utils.copyFile(self._nwFile, path.resolve(platform.releasePath, self.options.appName+'.app', 'Contents', 'Resources', 'nw.icns')));
+                copiedFiles.push(Utils.copyFile(self._nwFile, path.resolve(platform.releasePath, self.options.appName+'.app', 'Contents', 'Resources', 'app.nw')));
             }
         } else {
             // We cat the app.nw file into the .exe / nw


### PR DESCRIPTION
As per https://github.com/mllrsohn/node-webkit-builder/issues/86, when macZip: true is set, the app zip is being copied into nw.icns instead of app.nw
