### PR TITLE
Adding support for osx and win 64 bit builds.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -402,7 +402,7 @@ NwBuilder.prototype.mergeAppFiles = function () {
 
     this._forEachPlatform(function (name, platform) {
         // We copy the app files if we are on mac and don't force zip
-        if(name === 'osx') {
+        if(name === 'osx' || name === 'osx64') {
             // no zip, copy the files
             if(!self.options.macZip) {
                 self._files.forEach(function (file) {

--- a/lib/platforms.js
+++ b/lib/platforms.js
@@ -8,12 +8,28 @@ module.exports = {
         },
         versionNameTemplate: 'v${ version }/node-webkit-v${ version }-win-ia32.zip'
     },
+    win64: {
+        needsZip: true,
+        runable: 'nw.exe',
+        files: { // First file must be the executable
+            '<=0.9.2': ['nw.exe', 'ffmpegsumo.dll', 'icudt.dll', 'libEGL.dll', 'libGLESv2.dll', 'nw.pak', 'locales'],
+            '>0.9.2': ['nw.exe', 'ffmpegsumo.dll', 'icudtl.dat', 'libEGL.dll', 'libGLESv2.dll', 'nw.pak', 'locales']
+        },
+        versionNameTemplate: 'v${ version }/node-webkit-v${ version }-win-x64.zip'
+    },
     osx: {
         runable: 'node-webkit.app/Contents/MacOS/node-webkit',
         files: {
             '*': ['node-webkit.app']
         },
         versionNameTemplate: 'v${ version }/node-webkit-v${ version }-osx-ia32.zip'
+    },
+    osx64: {
+        runable: 'node-webkit.app/Contents/MacOS/node-webkit',
+        files: {
+            '*': ['node-webkit.app']
+        },
+        versionNameTemplate: 'v${ version }/node-webkit-v${ version }-osx-x64.zip'
     },
     linux32: {
         needsZip: true,


### PR DESCRIPTION
I noticed nodewebkit now has 64 bit builds for Windows and Linux so I added osx64 and win64 as build options. These don't interfere in anyway with the current 32 bit builds.
