### PR TITLE
Use `archive.bulk()` to avoid EMFILE errors (graceful-ncp)

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -125,14 +125,20 @@ module.exports = {
             archive.on('error', reject);
 
             // Add the files
-            files.forEach(function (file) {
+            var filesBulk = [];
+            files.forEach(function(file){
                 if(file.dest === 'package.json' && platformSpecificManifest){
                     archive.append(platformSpecificManifest, {name: 'package.json'});
                 }
-                else {
-                    archive.file(file.src, { name:file.dest });
+                else
+                {
+                    filesBulk.push({
+                        src: file.src,
+                        data: { name: file.dest }
+                    });
                 }
-            });
+            })
+            archive.bulk(filesBulk)
 
             // Some logs
             archive.on('entry', function (file) {


### PR DESCRIPTION
As per the documentation, the `archive.bulk()` call promises to avoid
EMFILE errors (too many open files).

[This pull request targets the graceful-ncp branch](https://github.com/mllrsohn/node-webkit-builder/pull/118#issuecomment-64493961)
