### PR TITLE
Fixes #130, make CFBundleIdentifier dependent on package name if not set...

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -177,6 +177,11 @@ module.exports = {
             }
         });
 
+        // Bundle identifier based on package name
+        if(options.CFBundleIdentifier === undefined) {
+            options.CFBundleIdentifier = 'com.node-webkit-builder.' + options.CFBundleName.toLowerCase().replace(/[^a-z\-]/g,'');
+        }
+
         // Read the input file
         return readFile(plistInput, 'utf8')
             // Parse it

--- a/test/expected/Info.plist
+++ b/test/expected/Info.plist
@@ -13,7 +13,7 @@
     <key>CFBundleIconFile</key>
     <string>nw.icns</string>
     <key>CFBundleIdentifier</key>
-    <string>com.intel.nw</string>
+    <string>com.node-webkit-builder.testapp</string>
     <key>CFBundleInfoDictionaryVersion</key>
     <string>6.0</string>
     <key>CFBundleName</key>


### PR DESCRIPTION
Make CFBundleIdentifier dependent on package name if not set in options. Fixes issue #130.

CFBundleIdentifier will look like this `com.node-webkit-builder.[packagename]` where `packagename` is the lowercase, striped of `[^a-z\-]` version of `CFBundleName` ([see Apples guidelines](https://developer.apple.com/library/mac/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html)).
