### PR TITLE
Fix for #139

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -467,30 +467,31 @@ NwBuilder.prototype.writePlatformSpecificManifest = function(platform, dest){
 };
 
 NwBuilder.prototype.handleMacApp = function () {
-    var self = this, allDone = [];
-    var macPlatform = this._platforms.osx;
+    var self = this,
+        allDone = [];
 
-    if(!macPlatform) return Promise.resolve();
+    this._forEachPlatform(function (name, platform) {
+        if(['osx32', 'osx64'].indexOf(name) < 0) return;
 
-    // Let's first handle the mac icon
-    if(self.options.macIcns) {
-        allDone.push(Utils.copyFile(self.options.macIcns, path.resolve(macPlatform.releasePath, self.options.appName+'.app', 'Contents', 'Resources', 'nw.icns')));
-    }
+        // Let's first handle the mac icon
+        if(self.options.macIcns) {
+            allDone.push(Utils.copyFile(self.options.macIcns, path.resolve(platform.releasePath, self.options.appName+'.app', 'Contents', 'Resources', 'nw.icns')));
+        }
 
-    // Handle mac credits
-    if(self.options.macCredits) {
-        allDone.push(Utils.copyFile(self.options.macCredits, path.resolve(macPlatform.releasePath, self.options.appName+'.app', 'Contents', 'Resources', 'Credits.html')));
-    }
+        // Handle mac credits
+        if(self.options.macCredits) {
+            allDone.push(Utils.copyFile(self.options.macCredits, path.resolve(platform.releasePath, self.options.appName+'.app', 'Contents', 'Resources', 'Credits.html')));
+        }
 
-    // Let handle the Plist
-    var PlistPath = path.resolve(macPlatform.releasePath, self.options.appName+'.app', 'Contents', 'Info.plist');
+        // Let's handle the Plist
+        var PlistPath = path.resolve(platform.releasePath, self.options.appName+'.app', 'Contents', 'Info.plist');
 
-    // If the macPlist is a string we just copy the file
-    if(typeof self.options.macPlist === 'string') {
-        allDone.push(Utils.copyFile(self.options.macPlist, PlistPath));
-    } else {
-        // Setup the Plst
-        var plistOptions = Utils.getPlistOptions(
+        // If the macPlist is a string we just copy the file
+        if(typeof self.options.macPlist === 'string') {
+            allDone.push(Utils.copyFile(self.options.macPlist, PlistPath));
+        } else {
+            // Setup the Plist
+            var plistOptions = Utils.getPlistOptions(
                 {
                     name: self.options.appName,
                     version: self.options.appVersion,
@@ -499,42 +500,46 @@ NwBuilder.prototype.handleMacApp = function () {
                 self.options.macPlist
             );
 
-        allDone.push(Utils.editPlist(PlistPath, PlistPath, plistOptions));
-    }
+            allDone.push(Utils.editPlist(PlistPath, PlistPath, plistOptions));
+        }
+    });
 
     return Promise.all(allDone);
-
 };
 
 NwBuilder.prototype.handleWinApp = function () {
     var self = this,
-        done = Promise.defer();
-    var winPlatform = this._platforms.win;
-    if(!winPlatform || !self.options.winIco) return Promise.resolve();
+        allDone = [];
 
-    // Set icon
-    if (self.options.winIco) {
-        self.emit('log', 'Update executable icon');
-        winresourcer({
-            operation: "Update",
-            exeFile: path.resolve(winPlatform.releasePath, _.first(winPlatform.files)),
-            resourceType: "Icongroup",
-            resourceName: "IDR_MAINFRAME",
-            lang: 1033, // Required, except when updating or deleting
-            resourceFile: path.resolve(self.options.winIco)
-        }, function(err) {
-            if(err) {
-                done.reject('Error while updating the Windows icon.' +
-                        (process.platform !== "win32" ? ' Wine (winehq.org) must be installed to add custom icons from Mac and Linux.' : '')
-                );
-            }
-            else {
-                done.resolve();
-            }
-        });
-    }
+    this._forEachPlatform(function (name, platform) {
+        if(!self.options.winIco || ['win32', 'win64'].indexOf(name) < 0) return;
 
-    return done.promise;
+        // build a promise chain
+        allDone.push(new Promise(function(resolve, reject) {
+            self.emit('log', 'Update ' + name + ' executable icon');
+            // Set icon
+            winresourcer({
+                operation: "Update",
+                exeFile: path.resolve(platform.releasePath, _.first(platform.files)),
+                resourceType: "Icongroup",
+                resourceName: "IDR_MAINFRAME",
+                lang: 1033, // Required, except when updating or deleting
+                resourceFile: path.resolve(self.options.winIco)
+            }, function(err) {
+                if(!err) { resolve(); }
+                else {
+                    reject('Error while updating the Windows icon.' +
+                        (process.platform !== "win32"
+                            ? ' Wine (winehq.org) must be installed to add custom icons from Mac and Linux.'
+                            : ''
+                        )
+                    );
+                }
+            });
+        }));
+    });
+
+    return Promise.all(allDone);
 };
 
 NwBuilder.prototype.runApp = function () {


### PR DESCRIPTION
This fixes #139...
`handleMacApp` and `handleWinApp` haven't been upgraded after the platform name changes.
