### PR TITLE
Add option to disable merging the zip file with the node webkit executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,12 @@ Default value: `null`
 
 WINDOWS ONLY: The path to your ICO icon file. If your don't provide your own it will use the one provided by node-webkit. If you are building on MAC or LINUX you must have [Wine](http://winehq.org) installed to use this option.
 
+#### options.mergeZip
+Type: `Boolean`
+Default value: `true`
+
+WINDOWS AND LINUX ONLY: Merge the source file package with the Node Webkit executable.
+
 ### Manifest Options
 
 #### platformOverrides

--- a/lib/index.js
+++ b/lib/index.js
@@ -37,6 +37,7 @@ function NwBuilder(options) {
         macIcns: false,
         macZip: false,
         macPlist: false,
+        mergeZip: true,
         winIco: null,
         argv: process.argv.slice(2)
     };
@@ -448,6 +449,13 @@ NwBuilder.prototype.mergeAppFiles = function () {
                     self
                 ));
             }
+        } else if (!self.options.mergeZip) {
+            // copy the zipped package.nw into the app directory
+            copiedFiles.push(Utils.copyFile(
+                self.getZipFile(name),
+                path.resolve(platform.releasePath, 'package.nw'),
+                self
+            ));
         } else {
             // We cat the app.nw file into the .exe / nw
             copiedFiles.push(Utils.mergeFiles(


### PR DESCRIPTION
Optional zip file merging on Windows/Linux is helpful for Node Webkit app updaters that update the source file package separately from the executable.
