### PR TITLE
Fix resource settings handling, allow to set icon with rcedit

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -73,6 +73,7 @@ function NwBuilder(options) {
         macPlist: false,
         winVersionString: {},
         winIco: null,
+        useRcedit: false,
         argv: process.argv.slice(2)
     };
     // Intercept the platforms and check for the legacy platforms of 'osx' and 'win' and
@@ -674,40 +675,51 @@ NwBuilder.prototype.handleWinApp = function () {
         allDone = [];
 
     this._forEachPlatform(function (name, platform) {
-        if(!self.options.winIco || ['win32', 'win64'].indexOf(name) < 0) return;
+        if((!self.options.winIco && !self.options.winVersionString) || ['win32', 'win64'].indexOf(name) < 0) return;
 
         var executableName = self._version.isLegacy ? _.first(platform.files) : self.getExecutableName(name);
         var executablePath =  path.resolve(platform.releasePath, executableName);
 
-        var updateVersionStringPromise = rcedit(executablePath, {
-            'version-string': Object.assign({}, {
-                // The process name used in the Task Manager
-                FileDescription: self.options.appName,
-            }, self.options.winVersionString)
-        });
+        rcConf = {};
+        if(self.options.winVersionString) {
+          rcConf['version-string'] = Object.assign({}, {
+              // The process name used in the Task Manager
+              FileDescription: self.options.appName,
+          }, self.options.winVersionString);
+        }
+        if(self.options.winIco && self.options.useRcedit){
+          rcConf['icon'] = path.resolve(self.options.winIco);
+        }
+
+        var updateVersionStringPromise = rcedit(executablePath, rcConf);
 
         var updateIconsPromise = updateVersionStringPromise.then(function() {
             return new Promise(function(resolve, reject) {
-                self.emit('log', 'Update ' + name + ' executable icon');
-                // Set icon
-                winresourcer({
-                    operation: "Update",
-                    exeFile: executablePath,
-                    resourceType: "Icongroup",
-                    resourceName: "IDR_MAINFRAME",
-                    lang: 1033, // Required, except when updating or deleting
-                    resourceFile: path.resolve(self.options.winIco)
-                }, function(err) {
-                    if(!err) { resolve(); }
-                    else {
-                        reject('Error while updating the Windows icon.' +
-                            (process.platform !== "win32"
-                                    ? ' Wine (winehq.org) must be installed to add custom icons from Mac and Linux.'
-                                    : ''
-                            )
-                        );
-                    }
-                });
+                if(!self.options.winIco || self.options.useRcedit) {
+                    resolve();
+                }
+                else {
+                    self.emit('log', 'Update ' + name + ' executable icon');
+                    // Set icon
+                    winresourcer({
+                        operation: "Update",
+                        exeFile: executablePath,
+                        resourceType: "Icongroup",
+                        resourceName: "IDR_MAINFRAME",
+                        lang: 1033, // Required, except when updating or deleting
+                        resourceFile: path.resolve(self.options.winIco)
+                    }, function(err) {
+                        if(!err) { resolve(); }
+                        else {
+                            reject('Error while updating the Windows icon.' +
+                                (process.platform !== "win32"
+                                        ? ' Wine (winehq.org) must be installed to add custom icons from Mac and Linux.'
+                                        : ''
+                                )
+                            );
+                        }
+                    });
+                }
             });
         });
 


### PR DESCRIPTION
The current code regarding setting windows resources on the executable is somewhat broken. It will not work when only winVersionString is set. It only runs when winIco is set, but then it also overwrites the winVersionString even when it is not set in the config.

Also this change adds a new option 'useRcedit' which when set will set the icon with rcedit instead of calling winresourcer. Apparently nw-builder used to use rcedit for the icon until it was changed in 2014 because there were some problems. I don't know if this was fixed in rcedit, but with a properly prepared icon-file I had no problems at all setting it with rcedit, but I could not get winresourcer running on Linux with wine.

So with this flag the user can now choose if he wants/must use winresourcer or if rcedit will do, which is less of a hassle.