### PR TITLE
fix(cli): add missing options

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## Added
+
+- Added options `buildType`, `macCredits`, `macPlist`, `zip`, `zipOptions` to CLI [#575](https://github.com/nwjs-community/nw-builder/pull/575)
+
 ## [3.7.1] - 2022-06-02
 
 ## Changed

--- a/bin/nwbuild.cjs
+++ b/bin/nwbuild.cjs
@@ -62,12 +62,15 @@ const options = {
   platforms: argv.platforms ? argv.platforms.split(",") : [currentPlatform],
   currentPlatform: currentPlatform,
   version: argv.version,
+  macCredits: argv.macCredits || false,
+  macPlist: argv.macPlist || false,
   macIcns: argv.macIcns || false,
   winIco: argv.winIco || false,
   cacheDir: argv.cacheDir
     ? path.resolve(process.cwd(), argv.cacheDir)
     : path.resolve(__dirname, "..", "cache"),
   buildDir: path.resolve(process.cwd(), argv.buildDir),
+  buildType: argv.buildType || 'default',
   forceDownload: argv.forceDownload,
   // get all argv arguments after --
   argv: process.argv.slice(
@@ -75,6 +78,8 @@ const options = {
       return el === "--";
     }) + 1,
   ),
+  zip: argv.zip || null,
+  zipOptions: argv.zipOptions || null
 };
 
 // Initialize Builder


### PR DESCRIPTION
Fixes: #456, #458, #539

### Changes

- Added `buildType`, `macCredits`, `macPlist`, `zip`, `zipOptions` to CLI
