### PR TITLE
fix(utils): do not append `Version` before `CFBundleShortVersionString`

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## Removed
+
+- Remove `Version` from `CFBundleShortVersionString` [#576](https://github.com/nwjs-community/nw-builder/pull/576)
+
 ## [3.7.2] - 2022-06-02
 
 ## Added

--- a/lib/utils.cjs
+++ b/lib/utils.cjs
@@ -202,7 +202,7 @@ module.exports = {
     }
     if (parsedParams.version) {
       obj.CFBundleVersion = parsedParams.version;
-      obj.CFBundleShortVersionString = "Version " + parsedParams.version;
+      obj.CFBundleShortVersionString = parsedParams.version;
     }
     if (parsedParams.copyright) {
       obj.NSHumanReadableCopyright = parsedParams.copyright;

--- a/test/expected/osx-plist/1.plist
+++ b/test/expected/osx-plist/1.plist
@@ -21,7 +21,7 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>
-    <string>Version 1.3.3.7</string>
+    <string>1.3.3.7</string>
     <key>CFBundleVersion</key>
     <string>1.3.3.7</string>
     <key>LSFileQuarantineEnabled</key>

--- a/test/expected/osx-plist/2.plist
+++ b/test/expected/osx-plist/2.plist
@@ -21,7 +21,7 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>
-    <string>Version 1.3.3.7</string>
+    <string>1.3.3.7</string>
     <key>CFBundleVersion</key>
     <string>1.3.3.7</string>
     <key>LSFileQuarantineEnabled</key>


### PR DESCRIPTION
Fixes: #505

### Changes

- [Do not prefix](https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleshortversionstring) `CFBundleShortVersionString` with `Version`
