### PR TITLE
fix: failure if cache dir does not exist

### DIFF
--- a/src/nwbuild.js
+++ b/src/nwbuild.js
@@ -65,7 +65,6 @@ const nwbuild = async ({
     }
   }
 
-  let releaseInfo = await getReleaseInfo(version, cacheDir, manifestUrl);
   let nwDir = `${cacheDir}/nwjs${
     flavour === "sdk" ? "-sdk" : ""
   }-v${version}-${platform}-${arch}`;
@@ -84,6 +83,8 @@ const nwbuild = async ({
     await decompress(platform, cacheDir);
     await remove(platform, cacheDir);
   }
+
+  let releaseInfo = await getReleaseInfo(version, cacheDir, manifestUrl);
 
   if (run === true) {
     await develop(srcDir, nwDir, platform);


### PR DESCRIPTION
Fixes: #691

### Changes

- Check for release info after downloading cache
