### PR TITLE
fix: `osx` builds to allow nwjs launch

### DIFF
--- a/src/bld/osxCfg.js
+++ b/src/bld/osxCfg.js
@@ -10,7 +10,8 @@ import plist from "plist";
  * @param {string} outDir       The directory to hold build artifacts
  * @param {object} releaseInfo  NW binary release metadata
  */
-const setOsxConfig = async (pkg, outDir, releaseInfo) => {
+const setOsxConfig = async (pkg, outDir) => {
+// const setOsxConfig = async (pkg, outDir, releaseInfo) => {
   const outApp = path.resolve(outDir, `${pkg.name}.app`);
   await fs.rename(path.resolve(outDir, "nwjs.app"), outApp);
 

--- a/src/bld/package.js
+++ b/src/bld/package.js
@@ -27,7 +27,7 @@ const packager = async (srcDir, nwDir, outDir, platform, zip, releaseInfo) => {
   await cp(
     srcDir,
     `${outDir}/${
-      platform !== "osx" ? "package.nw" : "nwjs.app/Contents/Resources/nw.app"
+      platform !== "osx" ? "package.nw" : "nwjs.app/Contents/Resources/app.nw"
     }`,
     {
       recursive: true,
@@ -37,7 +37,7 @@ const packager = async (srcDir, nwDir, outDir, platform, zip, releaseInfo) => {
   log.debug("Get NW's package.json as a buffer");
   let buffer = await readFile(
     `${outDir}/${
-      platform !== "osx" ? "package.nw" : "nwjs.app/Contents/Resources/nw.app"
+      platform !== "osx" ? "package.nw" : "nwjs.app/Contents/Resources/app.nw"
     }/package.json`,
   );
   log.debug("Convert package.json buffer into JSON");


### PR DESCRIPTION
This partially fixes macOS builds, but the entire renaming of helpers is commented out. With those changes enabled, NW.js won't launch. This PR at least gets builds to work, but the helpers are still named "nwjs". Will follow-up with Jared and/or the NW.js mailing list to determine what the proper procedure is.

### Changes

- Replaces `nw.app` with `app.nw` for `osx` packaging step.
- Cleans up `osxCfg.js` to remove repetitive code and implement `node:path`.
- Implement `InfoPlist.strings` modification.
- Implement `product_string` property in `package.json` (currently disabled).