### PR TITLE
fix(win-bld): skip modify exe if platform is not windows or wine is not installed

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "demo:osx": "npm run cjs && cd ./test/e2e && node osx.cjs",
     "demo:win": "npm run cjs && cd ./test/e2e && node win.cjs",
     "cjs": "esbuild ./src/nwbuild.js --bundle --minify --legal-comments=inline --platform=node --outfile=./dist/nwbuild.cjs",
-    "checklist": "npm run cjs && npm run format && npm run lint && npm run test"
+    "checklist": "npm run cjs && npm run format && npm run lint && npm run test:unit && npm run test:e2e"
   },
   "devDependencies": {
     "esbuild": "^0.16.3",

--- a/src/bld/winCfg.js
+++ b/src/bld/winCfg.js
@@ -1,5 +1,4 @@
 import { rename } from "node:fs/promises";
-import { platform } from "node:process";
 
 import rcedit from "rcedit";
 
@@ -40,19 +39,16 @@ const setWinConfig = async (app, outDir) => {
   try {
     await rename(`${outDir}/nw.exe`, `${outDir}/${app.name}.exe`);
 
-    if (platform === "win32") {
-      await rcedit(`${outDir}/${app.name}.exe`, {
-        "file-version": app.version,
-        "icon": app.icon,
-        "product-version": app.version,
-        "version-string": versionString,
-      });
-    } else {
-      throw new Error(
-        `The exe cannot be modified on platform ${platform}. Either install Wine or build on a Windows OS. `,
-      );
-    }
+    await rcedit(`${outDir}/${app.name}.exe`, {
+      "file-version": app.version,
+      "icon": app.icon,
+      "product-version": app.version,
+      "version-string": versionString,
+    });
   } catch (error) {
+    log.warn(
+      "Unable to modify EXE. Ensure WINE is installed or build in Windows",
+    );
     log.error(error);
   }
 };

--- a/src/bld/winCfg.js
+++ b/src/bld/winCfg.js
@@ -1,6 +1,9 @@
 import { rename } from "node:fs/promises";
+import { platform } from "node:process";
 
 import rcedit from "rcedit";
+
+import { log } from "../log.js";
 
 /**
  * Windows specific configuration steps
@@ -34,13 +37,24 @@ const setWinConfig = async (app, outDir) => {
     }
   });
 
-  await rename(`${outDir}/nw.exe`, `${outDir}/${app.name}.exe`);
-  await rcedit(`${outDir}/${app.name}.exe`, {
-    "file-version": app.version,
-    "icon": app.icon,
-    "product-version": app.version,
-    "version-string": versionString,
-  });
+  try {
+    await rename(`${outDir}/nw.exe`, `${outDir}/${app.name}.exe`);
+
+    if (platform === "win32") {
+      await rcedit(`${outDir}/${app.name}.exe`, {
+        "file-version": app.version,
+        "icon": app.icon,
+        "product-version": app.version,
+        "version-string": versionString,
+      });
+    } else {
+      throw new Error(
+        `The exe cannot be modified on platform ${platform}. Either install Wine or build on a Windows OS. `,
+      );
+    }
+  } catch (error) {
+    log.error(error);
+  }
 };
 
 export { setWinConfig };

--- a/src/nwbuild.js
+++ b/src/nwbuild.js
@@ -108,7 +108,7 @@ export const nwbuild = async (options) => {
     // Download relevant NW.js binaries
     if (cached === false) {
       log.debug("Download relevant NW.js binaries");
-      log.debug(options.downloadUrl)
+      log.debug(options.downloadUrl);
       await download(
         options.version,
         options.flavor,

--- a/src/nwbuild.js
+++ b/src/nwbuild.js
@@ -108,7 +108,6 @@ export const nwbuild = async (options) => {
     // Download relevant NW.js binaries
     if (cached === false) {
       log.debug("Download relevant NW.js binaries");
-      log.debug(options.downloadUrl);
       await download(
         options.version,
         options.flavor,

--- a/test/e2e/osx.cjs
+++ b/test/e2e/osx.cjs
@@ -5,7 +5,7 @@ nwbuild({
   mode: "build",
   version: "0.70.1",
   flavour: "normal",
-  platform: "linux",
+  platform: "osx",
   arch: "x64",
   outDir: "./build/osx",
 });


### PR DESCRIPTION
Fixes: #714

### Changes

- handle `rcedit` error on missing wine or if platform is not windows
