### PR TITLE
fix: prevent nuking `options.app`, use absolute path for `rcedit`

### DIFF
--- a/src/bld/package.js
+++ b/src/bld/package.js
@@ -34,7 +34,7 @@ const packager = async (
   log.debug(`Copy ${nwDir} files to ${outDir} directory`);
   await cp(nwDir, outDir, { recursive: true });
 
-  log.debug(`Copy ${nwDir} files to ${outDir} directory`);
+  log.debug(`Copy files in srcDir to ${outDir} directory`);
   for (let file of files) {
     log.debug(`Copy ${file} file to ${outDir} directory`);
     await cp(

--- a/src/bld/winCfg.js
+++ b/src/bld/winCfg.js
@@ -37,17 +37,20 @@ const setWinConfig = async (app, outDir) => {
   });
 
   try {
-    await rename(`${outDir}/nw.exe`, `${outDir}/${app.name}.exe`);
-
-    await rcedit(`${outDir}/${app.name}.exe`, {
-      "file-version": app.version,
-      "icon": app.icon,
-      "product-version": app.version,
-      "version-string": versionString,
-    });
+    const outDirAppExe = resolve(outDir, `${app.name}.exe`);
+    await rename(resolve(outDir, 'nw.exe'), outDirAppExe);
+    await rcedit(
+      outDirAppExe,
+      {
+        "file-version": app.version,
+        "icon": app.icon,
+        "product-version": app.version,
+        "version-string": versionString,
+      },
+    );
   } catch (error) {
     log.warn(
-      "Unable to modify EXE. Ensure WINE is installed or build in Windows",
+      "Renaming EXE failed or unable to modify EXE. If it's the latter, ensure WINE is installed or build in Windows",
     );
     log.error(error);
   }

--- a/src/util/parse.js
+++ b/src/util/parse.js
@@ -28,7 +28,7 @@ export const parse = async (options, pkg) => {
   options.cacheDir = resolve(options.cacheDir ?? "./cache");
   options.downloadUrl = options.downloadUrl ?? "https://dl.nwjs.io";
   options.manifestUrl = options.manifestUrl ?? "https://nwjs.io/versions";
-  options.app = {};
+  options.app = options.app ?? {};
   options.argv = options.argv ?? [];
   // linux desktop entry file configurations options
   options.app.name = options.app.name ?? pkg.name;


### PR DESCRIPTION
### Description

Fixes: #812 
Fixes: #813