### PR TITLE
Fixes missing `files` when calling `getManifest()` with glob disabled

### DIFF
--- a/src/nwbuild.js
+++ b/src/nwbuild.js
@@ -98,7 +98,7 @@ const nwbuild = async (options) => {
     options = await parse(options, manifest);
 
     if (options.mode !== "get") {
-      files = await getFiles(options.srcDir);
+      files = options.glob ? await getFiles(options.srcDir) : options.srcDir;
       manifest = await getManifest(files, options.glob);
       if (typeof manifest?.nwbuild === "object") {
         options = manifest.nwbuild;


### PR DESCRIPTION
When `glob` is set to `false`, the call to `getManifest()` was failing in Windows:

```
[ ERROR ] 2023-03-27T12:32:48.495Z ENOENT: no such file or directory, open 'C:\package.json'
```

This PR sets `files` to `options.srcDir` if `options.glob` is false. It works when globbing is disabled, but I don't know if it breaks anything when globbing is enabled.