### PR TITLE
fix: validate version

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,9 +48,9 @@
     "test:jest": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
     "test:unit": "node --test-reporter=spec --test test/unit/index.js",
     "test:e2e": "node --test-reporter=spec --test e2e/index.js",
-    "test:manual:get": "cd test/fixture && nwbuild --mode=get",
-    "test:manual:dev": "cd test/fixture && nwbuild --mode=run ./app --no-glob",
-    "test:manual:bld": "cd test/fixture && nwbuild --mode=build ./app --no-glob"
+    "test:manual:get": "cd test/fixture && nwbuild --mode=get --version=0.74.0",
+    "test:manual:dev": "cd test/fixture && nwbuild --mode=run --version=0.74.0 ./app --no-glob",
+    "test:manual:bld": "cd test/fixture && nwbuild --mode=build --version=0.74.0 ./app --no-glob"
   },
   "devDependencies": {
     "eslint": "^8.36.0",

--- a/src/nwbuild.js
+++ b/src/nwbuild.js
@@ -10,7 +10,7 @@ import { develop } from "./run/develop.js";
 import { isCached } from "./util/cache.js";
 import { replaceFfmpeg } from "./util/ffmpeg.js";
 import { getFiles } from "./util/files.js";
-import { getManifest } from "./util/manifest.js";
+import { getVersionManifest } from "./util/versionManifest.js";
 import { parse } from "./util/parse.js";
 import { validate } from "./util/validate.js";
 import { xattr } from "./util/xattr.js";
@@ -99,7 +99,7 @@ const nwbuild = async (options) => {
 
     if (options.mode !== "get") {
       files = options.glob ? await getFiles(options.srcDir) : options.srcDir;
-      manifest = await getManifest(files, options.glob);
+      manifest = await getVersionManifest(files, options.glob);
       if (typeof manifest?.nwbuild === "object") {
         options = manifest.nwbuild;
       }
@@ -129,16 +129,16 @@ const nwbuild = async (options) => {
       options.cacheDir,
       options.manifestUrl,
     );
-    // Remove leading "v" from version string
-    options.version = releaseInfo.version.slice(1);
 
     await validate(options, releaseInfo);
+
+    // Remove leading "v" from version string
+    options.version = releaseInfo.version.slice(1);
 
     // Variable to store nwDir file path
     nwDir = resolve(
       options.cacheDir,
-      `nwjs${options.flavor === "sdk" ? "-sdk" : ""}-v${options.version}-${
-        options.platform
+      `nwjs${options.flavor === "sdk" ? "-sdk" : ""}-v${options.version}-${options.platform
       }-${options.arch}`,
     );
 

--- a/src/util/validate.js
+++ b/src/util/validate.js
@@ -14,7 +14,9 @@ export const validate = async (options, releaseInfo) => {
       `Unknown mode ${options.mode}. Expected "get", "run" or "build".`,
     );
   }
-  // We don't validate version since getReleaseInfo already does that
+  if (typeof releaseInfo === "undefined") {
+    throw new Error("The specified version does not exist in the version manifest. Disable cache to redownload the version manifest. If you still get this error, that means the version you've specified is incorrect.");
+  }
   if (!releaseInfo.flavors.includes(options.flavor)) {
     throw new Error(
       `${options.flavor} flavor is not supported by this download server.`,

--- a/src/util/versionManifest.js
+++ b/src/util/versionManifest.js
@@ -8,7 +8,7 @@ import { basename } from "node:path";
  * @param  {boolean}         glob   Whether or not the files are glob patterns
  * @return {Promise<object>}        NW.js manifest file
  */
-export const getManifest = async (files, glob) => {
+export const getVersionManifest = async (files, glob) => {
   let manifest;
 
   if (glob === false) {


### PR DESCRIPTION
Fixes: #823

## Description

Throw error if `releaseInfo` is `undefined` (this implies `version` is invalid).
