### PR TITLE
Added verbatimSymLinks option to support relative symbolic links duri…

### DIFF
--- a/src/bld/build.js
+++ b/src/bld/build.js
@@ -45,7 +45,7 @@ export const build = async (
         outDir,
         platform !== "osx" ? "package.nw" : "nwjs.app/Contents/Resources/app.nw"
       ),
-      { recursive: true }
+      { recursive: true, verbatimSymlinks: true }
     );
   } else {
     for (let file of files) {
@@ -59,7 +59,7 @@ export const build = async (
             : "nwjs.app/Contents/Resources/app.nw",
           file
         ),
-        { recursive: true }
+        { recursive: true, verbatimSymlinks: true }
       );
     }
 


### PR DESCRIPTION
…ng file copy

Fixes: #
Relative symbolic links are not currently supported. This allows for these links to be preserved (relatively).

## Description
