### PR TITLE
fix(fs): preserve relative symlinks of NW.js files

### DIFF
--- a/src/bld/build.js
+++ b/src/bld/build.js
@@ -34,7 +34,7 @@ export const build = async (
   log.debug(`Remove any files at ${outDir} directory`);
   await rm(outDir, { force: true, recursive: true });
   log.debug(`Copy ${nwDir} files to ${outDir} directory`);
-  await cp(nwDir, outDir, { recursive: true });
+  await cp(nwDir, outDir, { recursive: true, verbatimSymlinks: true });
 
   log.debug(`Copy files in srcDir to ${outDir} directory`);
 


### PR DESCRIPTION
Fixes: #882

Continuation of #880

## Description

This makes the Nwjs files not have absolute paths in their symlinks. This may completely fix the osx64 code signing issue - maybe not. 