### PR TITLE
fix: change manifest cache impl

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [4.2.7] - 2023-06-27
+
+### Changed
+
+- Redownload `manifest.json` every time the `nwbuild` function is executed.
+- If `manifest.json` already exists and we are unable to connect to the `nwjs.io` domain, then use the existing manifest.
+
 ## [4.2.6] - 2023-06-20
 
 ### Changed

--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Redownload `manifest.json` every time the `nwbuild` function is executed.
 - If `manifest.json` already exists and we are unable to connect to the `nwjs.io` domain, then use the existing manifest.
+- If no `manifest.json` exists in the cache dir, then the `validate` function will cache this and throw an error - preventing the build.
 
 ## [4.2.6] - 2023-06-20
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nw-builder",
-  "version": "4.2.6",
+  "version": "4.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nw-builder",
-      "version": "4.2.6",
+      "version": "4.2.7",
       "license": "MIT",
       "dependencies": {
         "archiver": "^5.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nw-builder",
-  "version": "4.2.6",
+  "version": "4.2.7",
   "description": "Build NW.js desktop applications for MacOS, Windows and Linux.",
   "keywords": [
     "NW.js",

--- a/src/get/getManifest.js
+++ b/src/get/getManifest.js
@@ -11,7 +11,7 @@ import { log } from "../log.js";
 export const getManifest = (manifestUrl) => {
   let chunks = undefined;
 
-  return new Promise((resolve, reject) => {
+  return new Promise((resolve) => {
     const req = get(manifestUrl, (res) => {
       res.on("data", (chunk) => {
         chunks += chunk;

--- a/src/get/getManifest.js
+++ b/src/get/getManifest.js
@@ -12,20 +12,24 @@ export const getManifest = (manifestUrl) => {
   let chunks = undefined;
 
   return new Promise((resolve, reject) => {
-    get(manifestUrl, (res) => {
+    const req = get(manifestUrl, (res) => {
       res.on("data", (chunk) => {
         chunks += chunk;
       });
 
       res.on("error", (e) => {
         log.error(e);
-        reject(undefined);
+        resolve(undefined);
       });
 
       res.on("end", () => {
         log.debug("Succesfully cached manifest metadata");
         resolve(chunks);
       });
+    });
+    req.on("error", (e) => {
+      log.warn(e);
+      resolve(undefined);
     });
   });
 };

--- a/src/util/validate.js
+++ b/src/util/validate.js
@@ -16,7 +16,7 @@ export const validate = async (options, releaseInfo) => {
   }
   if (typeof releaseInfo === "undefined") {
     throw new Error(
-      "The specified version does not exist in the version manifest. Disable cache to redownload the version manifest. If you still get this error, that means the version you've specified is incorrect."
+      "Either the specific version info does not exist or the version manifest itself does not exist. In case of the latter, please check your internet connection and try again later."
     );
   }
   if (!releaseInfo.flavors.includes(options.flavor)) {


### PR DESCRIPTION
Fixes: #822

## Description

- Redownload `manifest.json` every time the `nwbuild` function is executed.
- If `manifest.json` already exists and we are unable to connect to the `nwjs.io` domain (network related issues), then use the existing manifest.
- If no `manifest.json` exists in the cache dir, then the validate function will catch this and throw an error - preventing the build.