### PR TITLE
feat: compress to `zip`, `tar` and `tgz` formats

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,8 @@
+node_modules
+
+cache
+out
+
+*.zip
+*.tar
+*.tgz

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## Added
+
+- Compress `outDir` to `zip`, `tar` and `tgz` formats.
+
 ## [4.2.8] - 2023-06-29
 
 ### Changed

--- a/src/bld/build.js
+++ b/src/bld/build.js
@@ -93,6 +93,18 @@ export const build = async (
       break;
   }
 
+  if (zip !== false) {
+    if (zip === true || zip === "zip") {
+      await compressing.zip.compressDir(outDir, `${outDir}.zip`);
+    } else if (zip === "tar") {
+      await compressing.tar.compressDir(outDir, `${outDir}.tar`);
+    } else if (zip === "tgz") {
+      await compressing.tgz.compressDir(outDir, `${outDir}.tgz`);
+    }
+
+    await rm(outDir, { recursive: true, force: true });
+  }
+
   if (zip === true || zip === "zip") {
     await compressing.zip.compressDir(outDir, `${outDir}.zip`);
     await rm(outDir, { recursive: true, force: true });

--- a/src/bld/build.js
+++ b/src/bld/build.js
@@ -104,9 +104,4 @@ export const build = async (
 
     await rm(outDir, { recursive: true, force: true });
   }
-
-  if (zip === true || zip === "zip") {
-    await compressing.zip.compressDir(outDir, `${outDir}.zip`);
-    await rm(outDir, { recursive: true, force: true });
-  }
 };

--- a/src/index.js
+++ b/src/index.js
@@ -31,7 +31,7 @@ import { log } from "./log.js";
  * @property {"https://nwjs.io/versions" | string} [manifestUrl="https://nwjs.io/versions"]  URI to download manifest from
  * @property {object}                              app                                       Refer to Linux/Windows Specific Options under Getting Started in the docs
  * @property {boolean}                             [cache=true]                              If true the existing cache is used. Otherwise it removes and redownloads it.
- * @property {boolean}                             [zip=false]                               If true the outDir directory is zipped
+ * @property {boolean | "zip" | "tar" | "tgz"}     [zip=false]                               If true, "zip", "tar" or "tgz" the outDir directory is compressed.
  * @property {boolean}                             [cli=false]                               If true the CLI is used to glob srcDir and parse other options
  * @property {boolean}                             [ffmpeg=false]                            If true the chromium ffmpeg is replaced by community version
  * @property {boolean}                             [glob=true]                               If true globbing is enabled


### PR DESCRIPTION
Fixes: #887

## Description

- Compress `outDir` to `zip`, `tar` and `tgz` formats.