### PR TITLE
feat: specify log level via `options.logLevel`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Added
 
 - Compress `outDir` to `zip`, `tar` and `tgz` formats.
+- Specify log level via `options.logLevel`.
+- Add platform, arch, Node and NW.js info in debug log
 
 ## [4.2.8] - 2023-06-29
 

--- a/changelog.md
+++ b/changelog.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Compress `outDir` to `zip`, `tar` and `tgz` formats.
 - Specify log level via `options.logLevel`.
-- Add platform, arch, Node and NW.js info in debug log
+- Add platform, arch, Node and NW.js info in debug log.
 
 ## [4.2.8] - 2023-06-29
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -15,6 +15,7 @@ type Options = {
     cli: boolean,
     ffmpeg: boolean,
     glob: boolean,
+    logLevel: "error" | "warn" | "info" | "debug"
 };
 
 declare function nwbuild(options: Options): Promise<unknown>;

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import { mkdir, rm } from "node:fs/promises";
 import { resolve } from "node:path";
+import { arch, platform, version } from "node:process";
 
 import { decompress } from "./get/decompress.js";
 import { download } from "./get/download.js";
@@ -15,7 +16,7 @@ import { parse } from "./util/parse.js";
 import { validate } from "./util/validate.js";
 import { xattr } from "./util/xattr.js";
 
-import { log } from "./log.js";
+import { log, setLogLevel } from "./log.js";
 
 /**
  * @typedef {object} Options Configuration options
@@ -35,6 +36,7 @@ import { log } from "./log.js";
  * @property {boolean}                             [cli=false]                               If true the CLI is used to glob srcDir and parse other options
  * @property {boolean}                             [ffmpeg=false]                            If true the chromium ffmpeg is replaced by community version
  * @property {boolean}                             [glob=true]                               If true globbing is enabled
+ * @property {"error" | "warn" | "info" | "debug"} [logLevel="info"]                         Specified log level.
  */
 
 /**
@@ -92,8 +94,17 @@ const nwbuild = async (options) => {
 
     await validate(options, releaseInfo);
 
+    setLogLevel(options.logLevel);
+
     // Remove leading "v" from version string
     options.version = releaseInfo.version.slice(1);
+
+    if (options.logLevel === "debug") {
+      log.debug(`Platform: ${platform}`);
+      log.debug(`Archicture: ${arch}`);
+      log.debug(`Node Version: ${version}`);
+      log.debug(`NW.js Version: ${options.version}\n`);
+    }
 
     // Variable to store nwDir file path
     nwDir = resolve(

--- a/src/log.js
+++ b/src/log.js
@@ -2,11 +2,11 @@ import { createLogger, format, transports } from "winston";
 
 const { combine, timestamp, printf } = format;
 
-const customFormat = printf(({ level, message, timestamp }) => {
-  return `[ ${level.toUpperCase()} ] ${timestamp} ${message}`;
+const customFormat = printf(({ level, message }) => {
+  return `[ ${level.toUpperCase()} ] ${message}`;
 });
 
-export const log = createLogger({
+export let log = createLogger({
   format: combine(timestamp(), customFormat),
   transports: [
     new transports.Console({
@@ -15,10 +15,18 @@ export const log = createLogger({
   ],
 });
 
-// if (process.env.NODE_ENV !== "production") {
-//   log.add(
-//     new transports.Console({
-//       level: "debug",
-//     }),
-//   );
-// }
+/**
+ * Sets the log level
+ *
+ * @param {import("./index.js").Options.logLevel} level  Log level
+ */
+export function setLogLevel(level) {
+  log = createLogger({
+    format: combine(timestamp(), customFormat),
+    transports: [
+      new transports.Console({
+        level: level,
+      }),
+    ],
+  });
+}

--- a/src/util/parse.js
+++ b/src/util/parse.js
@@ -24,6 +24,7 @@ export const parse = async (options, pkg) => {
   options.cacheDir = options.cacheDir ?? "./cache";
   options.cache = options.cache ?? true;
   options.ffmpeg = options.ffmpeg ?? false;
+  options.glob = options.glob ?? "info";
 
   if (options.mode === "get") {
     return { ...options };
@@ -43,7 +44,7 @@ export const parse = async (options, pkg) => {
   options.app = options.app ?? {};
   options.app.name = options.app.name ?? pkg.name;
 
-  // TODO: move this out to
+  // TODO(#737): move this out
   if (options.platform === "linux") {
     // linux desktop entry file configurations options
     options.app.name = options.app.name ?? pkg.name;

--- a/src/util/parse.js
+++ b/src/util/parse.js
@@ -24,7 +24,7 @@ export const parse = async (options, pkg) => {
   options.cacheDir = options.cacheDir ?? "./cache";
   options.cache = options.cache ?? true;
   options.ffmpeg = options.ffmpeg ?? false;
-  options.glob = options.glob ?? "info";
+  options.logLevel = options.logLevel ?? "info";
 
   if (options.mode === "get") {
     return { ...options };

--- a/src/util/validate.js
+++ b/src/util/validate.js
@@ -47,6 +47,17 @@ export const validate = async (options, releaseInfo) => {
     );
   }
 
+  if (
+    options.logLevel !== "error" &&
+    options.logLevel !== "warn" &&
+    options.logLevel !== "info" &&
+    options.logLevel !== "debug"
+  ) {
+    throw new Error(
+      "Expected 'error', 'warn', 'info' or 'debug'. Got " + options.logLevel
+    );
+  }
+
   if (options.mode === "get") {
     return undefined;
   }

--- a/test/fixture/demo.js
+++ b/test/fixture/demo.js
@@ -2,7 +2,9 @@ import nwbuild from "nw-builder";
 
 await nwbuild({
   mode: "build",
-  srcDir: "app/package.json app/src/**/*",
+  srcDir: "app",
   outDir: "out",
   zip: "zip",
+  logLevel: "debug",
+  glob: false,
 });

--- a/test/unit/parse.js
+++ b/test/unit/parse.js
@@ -24,6 +24,7 @@ describe("parse - get mode", () => {
       manifestUrl: "https://nwjs.io/versions",
       cache: true,
       ffmpeg: false,
+      logLevel: "info"
     };
 
     deepStrictEqual(actualOptions, expectedOptions);
@@ -51,6 +52,7 @@ describe("parse - get mode", () => {
         "https://raw.githubusercontent.com/nwutils/nw-builder/main/src/util/osx.arm.versions.json",
       cache: true,
       ffmpeg: false,
+      logLevel: "info"
     };
 
     deepStrictEqual(actualOptions, expectedOptions);
@@ -73,6 +75,7 @@ describe("parse - get mode", () => {
       manifestUrl: "https://nwjs.io/versions",
       cache: true,
       ffmpeg: false,
+      logLevel: "info"
     };
 
     deepStrictEqual(actualOptions, expectedOptions);
@@ -95,6 +98,7 @@ describe("parse - get mode", () => {
       manifestUrl: "https://nwjs.io/versions",
       cache: true,
       ffmpeg: false,
+      logLevel: "info"
     };
 
     deepStrictEqual(actualOptions, expectedOptions);
@@ -117,6 +121,7 @@ describe("parse - get mode", () => {
       manifestUrl: "https://nwjs.io/versions",
       cache: true,
       ffmpeg: true,
+      logLevel: "info"
     };
 
     deepStrictEqual(actualOptions, expectedOptions);

--- a/test/unit/validate.js
+++ b/test/unit/validate.js
@@ -46,6 +46,7 @@ describe("validate - get mode", () => {
         manifestUrl: "https://nwjs.io/versions",
         cache: true,
         ffmpeg: false,
+        logLevel: "info",
       },
       mockReleaseInfo,
       mockNodeVersion
@@ -69,6 +70,7 @@ describe("validate - get mode", () => {
           "https://raw.githubusercontent.com/nwutils/nw-builder/main/src/util/osx.arm.versions.json",
         cache: true,
         ffmpeg: false,
+        logLevel: "info",
       },
       mockArmReleaseInfo,
       mockArmNodeVersion
@@ -90,6 +92,7 @@ describe("validate - get mode", () => {
         manifestUrl: "https://nwjs.io/versions",
         cache: true,
         ffmpeg: false,
+        logLevel: "info",
       },
       mockReleaseInfo,
       mockNodeVersion
@@ -111,6 +114,7 @@ describe("validate - get mode", () => {
         manifestUrl: "https://nwjs.io/versions",
         cache: true,
         ffmpeg: false,
+        logLevel: "info",
       },
       mockReleaseInfo,
       mockNodeVersion
@@ -132,6 +136,7 @@ describe("validate - get mode", () => {
         manifestUrl: "https://nwjs.io/versions",
         cache: true,
         ffmpeg: true,
+        logLevel: "info",
       },
       mockReleaseInfo,
       mockNodeVersion


### PR DESCRIPTION
Fixes: #844 

## Description

- Specify log level via `options.logLevel`.
- Add platform, arch, Node and NW.js info in debug log.