### PR TITLE
fix(yargs): specify arguments types

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,9 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [4.3.2] - 2023-07-11
 
-## Changed
+## Added
 
-- Added descriptions and argument types for remaining cli arguments.
+- Descriptions and argument types for remaining cli arguments.
 
 ## [4.3.1] - 2023-07-07
 

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [4.3.2] - 2023-07-11
+
+## Changed
+
+- Added descriptions and argument types for remaining cli arguments.
+
 ## [4.3.1] - 2023-07-07
 
 ## Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -2429,9 +2429,9 @@
       }
     },
     "node_modules/find-cache-dir/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -4035,9 +4035,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
-      "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nw-builder",
-  "version": "4.3.1",
+  "version": "4.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nw-builder",
-      "version": "4.3.1",
+      "version": "4.3.2",
       "license": "MIT",
       "dependencies": {
         "cli-progress": "^3.12.0",

--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
     "doc:bld": "vitepress build doc",
     "test:unit": "node --test-reporter=spec --test test/unit/index.js",
     "test:e2e": "node --test-reporter=spec --test test/e2e/index.js",
-    "test:demo": "cd test/fixture && node demo.js",
-    "test:cli": "cd test/fixture && nwbuild --platform win --arch x64 --outDir out --glob=false app"
+    "test:mod": "cd test/fixture && node demo.js",
+    "test:cli": "cd test/fixture && nwbuild --platform win --arch x64 --outDir out --no-glob app"
   },
   "devDependencies": {
     "eslint": "^8.44.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "doc:bld": "vitepress build doc",
     "test:unit": "node --test-reporter=spec --test test/unit/index.js",
     "test:e2e": "node --test-reporter=spec --test test/e2e/index.js",
-    "test:demo": "cd test/fixture && node demo.js"
+    "test:demo": "cd test/fixture && node demo.js",
+    "test:cli": "cd test/fixture && nwbuild --platform win --arch x64 --outDir out --glob=false app"
   },
   "devDependencies": {
     "eslint": "^8.44.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nw-builder",
-  "version": "4.3.1",
+  "version": "4.3.2",
   "description": "Build NW.js desktop applications for MacOS, Windows and Linux.",
   "keywords": [
     "NW.js",

--- a/src/cli.js
+++ b/src/cli.js
@@ -32,6 +32,42 @@ const cli = yargs(hideBin(process.argv))
     type: "string",
     description: "NW.js build artifacts",
   })
+  .option("cacheDir", {
+    type: "string",
+    description: "Cache NW.js binaries",
+  })
+  .option("downloadUrl", {
+    type: "string",
+    description: "NW.js download server",
+  })
+  .option("manifestUrl", {
+    type: "string",
+    description: "NW.js version info",
+  })
+  .option("glob", {
+    type: "boolean",
+    description: "Flag to enable/disable globbing",
+  })
+  .option("app", {
+    type: "object",
+    description: "Platform specific app metadata. Refer to docs for more info",
+  })
+  .option("cache", {
+    type: "boolean",
+    description: "Flag to enable/disable caching",
+  })
+  .option("zip", {
+    type: "string",
+    description: "Flag to enable/disable compression",
+  })
+  .option("ffmpeg", {
+    type: "string",
+    description: "Flag to enable/disable downloading community ffmpeg",
+  })
+  .option("logLevel", {
+    type: "string",
+    description: "Specify log level",
+  })
   .parse();
 
 nwbuild({


### PR DESCRIPTION
Fixes: #899

## Description

Previously `--glob false` was being parsed as `options.glob = "false"`. This also affected other arguments of types `object` and `boolean`. By adding argument types for the arguments, `--glob false` or `--glob=false` is parsed as `options.glob = false` and the other arguments are also parsed correctly.