### PR TITLE
fix(osx): set `NSHumanReadableCopyright` property

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [4.3.3] - 2023-07-11
+
+## Changed
+
+- Set `NSHumanReadableCopyright` property in `*.app/Resources/en.lproj/InfoPlist.strings` to update copyright
+
+## Removed
+
+- `NSHumanReadableCopyright` from `Info.plist`
+
 ## [4.3.2] - 2023-07-11
 
 ## Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nw-builder",
-  "version": "4.3.2",
+  "version": "4.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nw-builder",
-      "version": "4.3.2",
+      "version": "4.3.3",
       "license": "MIT",
       "dependencies": {
         "cli-progress": "^3.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nw-builder",
-  "version": "4.3.2",
+  "version": "4.3.3",
   "description": "Build NW.js desktop applications for MacOS, Windows and Linux.",
   "keywords": [
     "NW.js",

--- a/src/bld/osxCfg.js
+++ b/src/bld/osxCfg.js
@@ -47,17 +47,6 @@ const setOsxConfig = async (app, outDir) => {
 
     const infoPlistPath = resolve(outApp, "Contents", "Info.plist");
     const infoPlistJson = plist.parse(await readFile(infoPlistPath, "utf-8"));
-    
-    const infoPlistStringsPath = resolve(outApp, "Contents", "Resources", "en.lproj", "InfoPlist.strings");
-    const infoPlistStringsData = await readFile(infoPlistStringsPath, "utf-8");
-
-    let infoPlistStringsDataArray = infoPlistStringsData.split("\n");
-
-    infoPlistStringsDataArray.forEach((line, idx, arr) => {
-      if (line.includes("NSHumanReadableCopyright")) {
-        arr[idx] = `NSHumanReadableCopyright = "${app.NSHumanReadableCopyright}";`;
-      }
-    });
 
     infoPlistJson.LSApplicationCategoryType = app.LSApplicationCategoryType;
     infoPlistJson.CFBundleIdentifier = app.CFBundleIdentifier;
@@ -66,6 +55,10 @@ const setOsxConfig = async (app, outDir) => {
     infoPlistJson.CFBundleSpokenName = app.CFBundleSpokenName;
     infoPlistJson.CFBundleVersion = app.CFBundleVersion;
     infoPlistJson.CFBundleShortVersionString = app.CFBundleShortVersionString;
+    infoPlistJson.NSHumanReadableCopyright = app.NSHumanReadableCopyright;
+
+    console.log(infoPlistJson);
+    process.exit(1);
 
     Object.keys(infoPlistJson).forEach((option) => {
       if (infoPlistJson[option] === undefined) {

--- a/src/bld/osxCfg.js
+++ b/src/bld/osxCfg.js
@@ -64,7 +64,6 @@ const setOsxConfig = async (app, outDir) => {
         arr[
           idx
         ] = `NSHumanReadableCopyright = "${app.NSHumanReadableCopyright}";`;
-        console.log(arr);
       }
     });
 

--- a/src/bld/osxCfg.js
+++ b/src/bld/osxCfg.js
@@ -47,6 +47,17 @@ const setOsxConfig = async (app, outDir) => {
 
     const infoPlistPath = resolve(outApp, "Contents", "Info.plist");
     const infoPlistJson = plist.parse(await readFile(infoPlistPath, "utf-8"));
+    
+    const infoPlistStringsPath = resolve(outApp, "Contents", "Resources", "en.lproj", "InfoPlist.strings");
+    const infoPlistStringsData = await readFile(infoPlistStringsPath, "utf-8");
+
+    let infoPlistStringsDataArray = infoPlistStringsData.split("\n");
+
+    infoPlistStringsDataArray.forEach((line, idx, arr) => {
+      if (line.includes("NSHumanReadableCopyright")) {
+        arr[idx] = `NSHumanReadableCopyright = "${app.NSHumanReadableCopyright}";`;
+      }
+    });
 
     infoPlistJson.LSApplicationCategoryType = app.LSApplicationCategoryType;
     infoPlistJson.CFBundleIdentifier = app.CFBundleIdentifier;
@@ -55,7 +66,6 @@ const setOsxConfig = async (app, outDir) => {
     infoPlistJson.CFBundleSpokenName = app.CFBundleSpokenName;
     infoPlistJson.CFBundleVersion = app.CFBundleVersion;
     infoPlistJson.CFBundleShortVersionString = app.CFBundleShortVersionString;
-    infoPlistJson.NSHumanReadableCopyright = app.NSHumanReadableCopyright;
 
     Object.keys(infoPlistJson).forEach((option) => {
       if (infoPlistJson[option] === undefined) {
@@ -64,6 +74,7 @@ const setOsxConfig = async (app, outDir) => {
     });
 
     await writeFile(infoPlistPath, plist.build(infoPlistJson));
+    await writeFile(infoPlistStringsPath, infoPlistStringsDataArray.toString().replace(/,/g, "\n"));
   } catch (error) {
     log.error(error);
   }

--- a/src/bld/osxCfg.js
+++ b/src/bld/osxCfg.js
@@ -57,9 +57,6 @@ const setOsxConfig = async (app, outDir) => {
     infoPlistJson.CFBundleShortVersionString = app.CFBundleShortVersionString;
     infoPlistJson.NSHumanReadableCopyright = app.NSHumanReadableCopyright;
 
-    console.log(infoPlistJson);
-    process.exit(1);
-
     Object.keys(infoPlistJson).forEach((option) => {
       if (infoPlistJson[option] === undefined) {
         delete infoPlistJson[option];
@@ -67,7 +64,6 @@ const setOsxConfig = async (app, outDir) => {
     });
 
     await writeFile(infoPlistPath, plist.build(infoPlistJson));
-    await writeFile(infoPlistStringsPath, infoPlistStringsDataArray.toString().replace(/,/g, "\n"));
   } catch (error) {
     log.error(error);
   }

--- a/src/bld/osxCfg.js
+++ b/src/bld/osxCfg.js
@@ -48,6 +48,26 @@ const setOsxConfig = async (app, outDir) => {
     const infoPlistPath = resolve(outApp, "Contents", "Info.plist");
     const infoPlistJson = plist.parse(await readFile(infoPlistPath, "utf-8"));
 
+    const infoPlistStringsPath = resolve(
+      outApp,
+      "Contents",
+      "Resources",
+      "en.lproj",
+      "InfoPlist.strings"
+    );
+    const infoPlistStringsData = await readFile(infoPlistStringsPath, "utf-8");
+
+    let infoPlistStringsDataArray = infoPlistStringsData.split("\n");
+
+    infoPlistStringsDataArray.forEach((line, idx, arr) => {
+      if (line.includes("NSHumanReadableCopyright")) {
+        arr[
+          idx
+        ] = `NSHumanReadableCopyright = "${app.NSHumanReadableCopyright}";`;
+        console.log(arr);
+      }
+    });
+
     infoPlistJson.LSApplicationCategoryType = app.LSApplicationCategoryType;
     infoPlistJson.CFBundleIdentifier = app.CFBundleIdentifier;
     infoPlistJson.CFBundleName = app.CFBundleName;
@@ -55,7 +75,6 @@ const setOsxConfig = async (app, outDir) => {
     infoPlistJson.CFBundleSpokenName = app.CFBundleSpokenName;
     infoPlistJson.CFBundleVersion = app.CFBundleVersion;
     infoPlistJson.CFBundleShortVersionString = app.CFBundleShortVersionString;
-    infoPlistJson.NSHumanReadableCopyright = app.NSHumanReadableCopyright;
 
     Object.keys(infoPlistJson).forEach((option) => {
       if (infoPlistJson[option] === undefined) {
@@ -64,6 +83,10 @@ const setOsxConfig = async (app, outDir) => {
     });
 
     await writeFile(infoPlistPath, plist.build(infoPlistJson));
+    await writeFile(
+      infoPlistStringsPath,
+      infoPlistStringsDataArray.toString().replace(/,/g, "\n")
+    );
   } catch (error) {
     log.error(error);
   }

--- a/test/fixture/demo.js
+++ b/test/fixture/demo.js
@@ -11,6 +11,6 @@ await nwbuild({
   app: {
     name: "demo",
     icon: "app/icon.icns",
-    NSHumanReadableCopyright: "Copyright 2023 NW Utils. All Rights Reserved."
+    NSHumanReadableCopyright: "Copyright 2023 NW.js Utils. All Rights Reserved."
   },
 });

--- a/test/fixture/demo.js
+++ b/test/fixture/demo.js
@@ -5,14 +5,12 @@ await nwbuild({
   version: "latest",
   srcDir: "app",
   platform: "osx",
-  arch: "arm64",
-  downloadUrl: "https://github.com/corwin-of-amber/nw.js/releases/download",
-  manifestUrl:
-    "https://raw.githubusercontent.com/nwutils/nw-builder/main/src/util/osx.arm.versions.json",
+  arch: "x64",
   outDir: "out",
   glob: false,
   app: {
     name: "demo",
     icon: "app/icon.icns",
+    NSHumanReadableCopyright: "Copyright 2023 NW Utils. All Rights Reserved."
   },
 });

--- a/test/fixture/demo.js
+++ b/test/fixture/demo.js
@@ -11,6 +11,7 @@ await nwbuild({
   app: {
     name: "demo",
     icon: "app/icon.icns",
-    NSHumanReadableCopyright: "Copyright 2023 NW.js Utils. All Rights Reserved."
+    NSHumanReadableCopyright:
+      "Copyright 2023 NW.js Utils. All Rights Reserved.",
   },
 });


### PR DESCRIPTION
Fixes: #897

## Description

- Correctly set `NSHumanReadableCopyright` property.

## Testing Steps

- Fork repo
- Checkout `dev-897` branch
- `npm install` dependencies
- `npm run test:mod` to build demo app
- Go to `test/fixture/out/demo.app/Resources/en.lproj/InfoPlist.strings`
- Verify that `NSHumanReadableCopyright = "Copyright 2023 NW.js Utils. All Rights Reserved.";` exists in file
- Go to file explorer/Finder, right click and get app details `demo.app`
- Verify that the copyright is `Copyright 2023 NW.js Utils. All Rights Reserved.`

cc @rocketVibes 