### PR TITLE
fix(win): enable icon

### DIFF
--- a/src/bld/winCfg.js
+++ b/src/bld/winCfg.js
@@ -13,6 +13,7 @@ import { log } from "../log.js";
  * @property {string} company           Company that produced the file—for example, Microsoft Corporation or Standard Microsystems Corporation, Inc. This string is required.
  * @property {string} fileDescription   File description to be presented to users. This string may be displayed in a list box when the user is choosing files to install. For example, Keyboard Driver for AT-Style Keyboards. This string is required.
  * @property {string} fileVersion       Version number of the file. For example, 3.10 or 5.00.RC2. This string is required.
+ * @property {string} icon              The path to the icon file. It should be a .ico file.
  * @property {string} internalName      Internal name of the file, if one exists—for example, a module name if the file is a dynamic-link library. If the file has no internal name, this string should be the original filename, without extension. This string is required.
  * @property {string} legalCopyright    Copyright notices that apply to the file. This should include the full text of all notices, legal symbols, copyright dates, and so on. This string is optional.
  * @property {string} legalTrademark    Trademarks and registered trademarks that apply to the file. This should include the full text of all notices, legal symbols, trademark numbers, and so on. This string is optional.
@@ -55,14 +56,20 @@ const setWinConfig = async (app, outDir) => {
     }
   });
 
+  const rcEditOptions = {
+    "file-version": app.version,
+    "product-version": app.version,
+    "version-string": versionString,
+  }
+
+  if (app.icon) {
+    rcEditOptions.icon = app.icon
+  }
+
   try {
     const outDirAppExe = resolve(outDir, `${app.name}.exe`);
     await rename(resolve(outDir, "nw.exe"), outDirAppExe);
-    await rcedit(outDirAppExe, {
-      "file-version": app.version,
-      "product-version": app.version,
-      "version-string": versionString,
-    });
+    await rcedit(outDirAppExe, rcEditOptions);
   } catch (error) {
     log.warn(
       "Renaming EXE failed or unable to modify EXE. If it's the latter, ensure WINE is installed or build your application Windows platform",


### PR DESCRIPTION
Fixes: Windows icon not appearing. 


## Description
rcedit is used to modify the windows executable. We need to add the icon option for the icon to be set. Without this modification the executable will never get the icon. 

While testing this locally was seeing weird issues when building the application in the same output directory over and over. 
I moved to using a script to build in different output directories and the builds are entirely consistent now.

It seems that this change originated from this pr #894