### PR TITLE
fix(get): return promise to await correctly

### DIFF
--- a/src/get.js
+++ b/src/get.js
@@ -102,10 +102,10 @@ export async function get({
     downloadUrl === "https://npmmirror.com/mirrors/nwjs"
   ) {
     url = `${downloadUrl}/v${version}/nwjs${
-        flavor === "sdk" ? "-sdk" : ""
-      }-v${version}-${platform}-${arch}.${
-        platform === "linux" ? "tar.gz" : "zip"
-      }`;
+      flavor === "sdk" ? "-sdk" : ""
+    }-v${version}-${platform}-${arch}.${
+      platform === "linux" ? "tar.gz" : "zip"
+    }`;
     out = resolve(cacheDir, `nw.${platform === "linux" ? "tgz" : "zip"}`);
   }
 


### PR DESCRIPTION
Fixes: #na


## Description
There is an issue when downloading binaries that the builder doesn't wait for them to download and copies files immediately. 
This causes issues when the target applications files are moved before the file is downloaded. 

To fix this we simply return the promise from the request object. This will then make the function correctly wait. We were seeing intermittent failures on Jenkins when the cache was purged. 

Run without the return 
![image](https://github.com/nwutils/nw-builder/assets/10822281/5174b878-1715-4f90-89a5-3ee6fd75d1bd)

Run with the return
![image](https://github.com/nwutils/nw-builder/assets/10822281/3f82602c-1ff2-4989-a174-9d9f0cd9b352)
