### PR TITLE
fix: move ffmpeg to correct folder after extract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ doc/api*.md
 doc/mode-get.md
 out
 tmp
+.idea

--- a/src/get.js
+++ b/src/get.js
@@ -123,7 +123,7 @@ export async function get({
   }
 
   // If not cached, then download.
-  if (nwCached === false) {
+  if (nwCached === false || ffmpeg === true) {
     log.debug(`Downloading binaries`);
     await mkdir(nwDir, { recursive: true });
 

--- a/src/get.js
+++ b/src/get.js
@@ -9,6 +9,7 @@ import compressing from "compressing";
 
 import { log } from "./log.js";
 import { PLATFORM_KV, ARCH_KV } from "./util.js";
+import { replaceFfmpeg } from "./util/ffmpeg.js";
 
 /**
  * _Note: This an internal function which is not called directly. Please see example usage below._
@@ -179,6 +180,10 @@ export async function get({
 
     // Remove compressed file after download and decompress.
     return request.then(async () => {
+      if (ffmpeg === true) {
+        await replaceFfmpeg(platform, nwDir, out);
+      }
+
       log.debug(`Binary decompressed starting removal`);
       await rm(resolve(cacheDir, "ffmpeg.zip"), {
         recursive: true,


### PR DESCRIPTION
Fixes: #916 

## Description
reinstate the `replaceFfmpeg` code that was removed during cleanup