### PR TITLE
Fix missing symlinks in unzip

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,27 +2,27 @@
 
 The following are the guidelines we expect our community members and maintainers to follow.
 
-* * *
+---
 
 ## Terminology and Scope
 
 **What defines a "maintainer"?**
 
-* A maintainer is anyone that interacts with the community on behalf of this project. Amount of code written is not a qualifier. A maintainer may include those who solely help in support roles such as in resolving issues, improving documentation, administrating or moderating forums/chatrooms, or any other non-coding specific roles. Maintainers also include those that are responsible for the building and upkeep of the project.
+- A maintainer is anyone that interacts with the community on behalf of this project. Amount of code written is not a qualifier. A maintainer may include those who solely help in support roles such as in resolving issues, improving documentation, administrating or moderating forums/chatrooms, or any other non-coding specific roles. Maintainers also include those that are responsible for the building and upkeep of the project.
 
 **What defines a "community member"?**
 
-* Anyone interacting with this project directly, including maintainers.
+- Anyone interacting with this project directly, including maintainers.
 
 **What is the scope of these guidelines?**
 
-* These guidelines apply only to this project and forms of communication directly related to it, such as issue trackers, forums, chatrooms, and in person events specific to this project. If a member is violating these guidelines outside of this project or on other platforms, that is beyond our scope and any grievances should be handled on those platforms.
+- These guidelines apply only to this project and forms of communication directly related to it, such as issue trackers, forums, chatrooms, and in person events specific to this project. If a member is violating these guidelines outside of this project or on other platforms, that is beyond our scope and any grievances should be handled on those platforms.
 
 **Discussing the guidelines:**
 
-* Discussions around these guidelines, improving, updating, or altering them, is permitted so long as the discussions do not violate any existing guidelines.
+- Discussions around these guidelines, improving, updating, or altering them, is permitted so long as the discussions do not violate any existing guidelines.
 
-* * *
+---
 
 ## Guidelines
 
@@ -34,12 +34,12 @@ Any discussion or communication that is primarily focused around an ideology, be
 
 ### Guidelines for maintainers
 
-* Maintainers must abide by the same rules as all other community members mentioned above. However, in addition, maintainers are held to a higher standard, explained below.
-* Maintainers should answer all questions politely.
-* If someone is upset or angry about something, it's probably because it's difficult to use, so thank them for bringing it to your attention and address ways to solve the problem. Maintainers should focus on the content of the message, and not on how it was delivered.
-* A maintainer should seek to update members when an issue they brought up is resolved.
+- Maintainers must abide by the same rules as all other community members mentioned above. However, in addition, maintainers are held to a higher standard, explained below.
+- Maintainers should answer all questions politely.
+- If someone is upset or angry about something, it's probably because it's difficult to use, so thank them for bringing it to your attention and address ways to solve the problem. Maintainers should focus on the content of the message, and not on how it was delivered.
+- A maintainer should seek to update members when an issue they brought up is resolved.
 
-* * *
+---
 
 ## Appropriate response to violations
 
@@ -50,6 +50,6 @@ How to respond to a community member or maintainer violating a guideline.
 1. If a maintainer is in violation of a guideline, they should be informed of such with a link to this document. If additional actions are required of the maintainer but not taken, then other maintainers should be informed of these inactions.
 1. If a maintainer repeatedly violates the guidelines established in this document, they should be politely warned that continuing to violate the rules may result in being banned from the community. This means revoking access and support to interactions relating directly to the project (issue trackers, chatrooms, forums, in person events, etc.). However, they may continue to use the technology in accordance with its license. In addition, future contributions to this project may be ignored as well.
 
-* * *
+---
 
 Based on version 1.0.3 from https://github.com/CodifiedConduct/coc-no-ideologies

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [4.3.9] - 2023-08-15
+
+### Changed
+
+- Some mac environments don't restore symlinks when using compressing lib. Now we will use system `unzip` command to extract zip files
+
 ## [4.3.8] - 2023-08-14
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nw-builder",
-  "version": "4.3.8",
+  "version": "4.3.9",
   "description": "Build NW.js desktop applications for MacOS, Windows and Linux.",
   "keywords": [
     "NW.js",

--- a/src/get.js
+++ b/src/get.js
@@ -164,6 +164,7 @@ export async function get({
                 .uncompress(out, ffmpeg ? nwDir : cacheDir)
                 .then(() => resolve());
             } else if (platform === "osx") {
+              //TODO: compressing package does not restore symlinks on some macOS (eg: circleCI)
               const exec = function (cmd) {
                 log.debug(cmd);
                 const result = child_process.spawnSync(cmd, {

--- a/src/get.js
+++ b/src/get.js
@@ -163,17 +163,20 @@ export async function get({
               compressing.tgz
                 .uncompress(out, ffmpeg ? nwDir : cacheDir)
                 .then(() => resolve());
-            } else if (platform === "osx"){
+            } else if (platform === "osx") {
               const exec = function (cmd) {
-                  log.debug(cmd);
-                  const result = child_process.spawnSync(cmd, {shell: true, stdio: 'inherit'});
-                  if (result.status !== 0) {
-                      log.debug(`Command failed with status ${result.status}`);
-                      if (result.error) console.log(result.error);
-                      process.exit(1);
-                  }
-              }
-              exec(`unzip -o "${out}" -d "${ffmpeg ? nwDir : cacheDir}"`)
+                log.debug(cmd);
+                const result = child_process.spawnSync(cmd, {
+                  shell: true,
+                  stdio: "inherit",
+                });
+                if (result.status !== 0) {
+                  log.debug(`Command failed with status ${result.status}`);
+                  if (result.error) console.log(result.error);
+                  process.exit(1);
+                }
+              };
+              exec(`unzip -o "${out}" -d "${ffmpeg ? nwDir : cacheDir}"`);
             } else {
               compressing.zip
                 .uncompress(out, ffmpeg ? nwDir : cacheDir)

--- a/src/get.js
+++ b/src/get.js
@@ -175,6 +175,7 @@ export async function get({
                   if (result.error) console.log(result.error);
                   process.exit(1);
                 }
+                resolve();
               };
               exec(`unzip -o "${out}" -d "${ffmpeg ? nwDir : cacheDir}"`);
             } else {

--- a/src/get.js
+++ b/src/get.js
@@ -10,6 +10,7 @@ import compressing from "compressing";
 import { log } from "./log.js";
 import { PLATFORM_KV, ARCH_KV } from "./util.js";
 import { replaceFfmpeg } from "./util/ffmpeg.js";
+import child_process from "child_process";
 
 /**
  * _Note: This an internal function which is not called directly. Please see example usage below._
@@ -162,6 +163,17 @@ export async function get({
               compressing.tgz
                 .uncompress(out, ffmpeg ? nwDir : cacheDir)
                 .then(() => resolve());
+            } else if (platform === "osx"){
+              const exec = function (cmd) {
+                  log.debug(cmd);
+                  const result = child_process.spawnSync(cmd, {shell: true, stdio: 'inherit'});
+                  if (result.status !== 0) {
+                      log.debug(`Command failed with status ${result.status}`);
+                      if (result.error) console.log(result.error);
+                      process.exit(1);
+                  }
+              }
+              exec(`unzip -o "${out}" -d "${ffmpeg ? nwDir : cacheDir}"`)
             } else {
               compressing.zip
                 .uncompress(out, ffmpeg ? nwDir : cacheDir)

--- a/src/get.js
+++ b/src/get.js
@@ -175,7 +175,7 @@ export async function get({
                   if (result.error) console.log(result.error);
                   process.exit(1);
                 }
-                resolve();
+                return resolve();
               };
               exec(`unzip -o "${out}" -d "${ffmpeg ? nwDir : cacheDir}"`);
             } else {


### PR DESCRIPTION
Fixes: #923

## Description
This uses macOS built in `unzip` tool to unzip packages. On some macOS environments, the javascript `compressing` utility isn't restoring symlinks