### PR TITLE
fix(cli): use asterisk import to import `yargs/helpers`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [4.5.2] - 2023-12-19
+
+### Changed
+
+- Fix `yargs/helpers` import for cli usage.
+
 ## [4.5.1] - 2023-12-19
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nw-builder",
-  "version": "4.5.1",
+  "version": "4.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nw-builder",
-      "version": "4.5.1",
+      "version": "4.5.2",
       "license": "MIT",
       "dependencies": {
         "cli-progress": "^3.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nw-builder",
-  "version": "4.5.1",
+  "version": "4.5.2",
   "description": "Build NW.js desktop applications for MacOS, Windows and Linux.",
   "keywords": [
     "NW.js",

--- a/src/cli.js
+++ b/src/cli.js
@@ -3,7 +3,7 @@
 import process from "node:process";
 
 import yargs from "yargs/yargs";
-import yargs_helpers from "yargs/helpers";
+import * as yargs_helpers from "yargs/helpers";
 
 import nwbuild from "./index.js";
 


### PR DESCRIPTION
Fixes: N/A

## Description

- Fix `yargs/helpers` import for cli usage.