### PR TITLE
chore(get): factor out https logic

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,8 +12,15 @@ jobs:
   e2e:
     strategy:
       matrix:
-        os: [macos-13, ubuntu-22.04, windows-2022]
-        node: [16, 18, 20, 21]
+        os: 
+        - macos-13
+        - ubuntu-22.04
+        - windows-2022
+        node:
+        - 16
+        - 18
+        - 20
+        - 21
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ nwbuild({
 
 ### Bugs
 
+- MacOS fails to unzip MacOS NW.js binaries consistently 
 - Add back error, info, warn and debug logs
 
 ### Features
@@ -293,7 +294,6 @@ nwbuild({
 - chore(cli): migrate from `yargs` to `commander`
 - chore(get): verify sha checksum for downloads
 - chore(util): factor out nw file paths finder
-- chore(get): factor out https downloader
 - chore(get): factor out nwjs downloader
 - chore(get): factor out ffmpeg downloader
 - chore(get): factor out node headers downloader

--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ nwbuild({
 ### External contributor
 
 - We use [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) style of commit messages.
+- When making changes, try to follow [SOLID](https://en.wikipedia.org/wiki/SOLID) and [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) principles.
 - Pull requests are squashed and merged onto the `main` branch.
 - Lint your code before commiting your change.
 - Add tests whenever possible.
@@ -289,14 +290,20 @@ nwbuild({
 ### Chores
 
 - chore(cicd): use `google-github-actions/release-please-action` to automate publishing to npm, updating changelog and creating releases
-- chore(test): add test cases for current features
-- chore(yargs): migrate to `commander`
+- chore(cli): migrate from `yargs` to `commander`
+- chore(get): verify sha checksum for downloads
 - chore(util): factor out nw file paths finder
 - chore(get): factor out https downloader
 - chore(get): factor out nwjs downloader
 - chore(get): factor out ffmpeg downloader
 - chore(get): factor out node headers downloader
-- chore(get): verify sha checksum for downloads
+- chore(bld): factor out core build step
+- chore(bld): factor out linux config
+- chore(bld): factor out macos config
+- chore(bld): factor out windows config
+- chore(bld): factor out native addon
+- chore(bld): factor out compressing
+- chore(bld): factor out managed manifest
 - chore(bld): move `.desktop` entry file logic to `create-desktop-shortcuts` package
 
 ## FAQ

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
       "devDependencies": {
         "@stylistic/eslint-plugin-js": "^1.5.4",
         "eslint": "^8.56.0",
+        "eslint-config-tjw-jsdoc": "^1.0.5",
         "eslint-plugin-jsdoc": "^48.0.2",
         "eslint-plugin-markdown": "^3.0.1",
         "jsdoc": "^4.0.2",
@@ -2115,6 +2116,38 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-config-tjw-jsdoc": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/eslint-config-tjw-jsdoc/-/eslint-config-tjw-jsdoc-1.0.5.tgz",
+      "integrity": "sha512-xCXNrV3+5DHNTKJX6DFBPdwzwLFKK4q+7WBVPrAtAm4BXx6wH2CdbMMLxs+y3W6+H+nO9YhhAtMQ0dXvhTsLVA==",
+      "dev": true,
+      "dependencies": {
+        "eslint-plugin-jsdoc": "^46.8.1"
+      }
+    },
+    "node_modules/eslint-config-tjw-jsdoc/node_modules/eslint-plugin-jsdoc": {
+      "version": "46.10.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-46.10.1.tgz",
+      "integrity": "sha512-x8wxIpv00Y50NyweDUpa+58ffgSAI5sqe+zcZh33xphD0AVh+1kqr1ombaTRb7Fhpove1zfUuujlX9DWWBP5ag==",
+      "dev": true,
+      "dependencies": {
+        "@es-joy/jsdoccomment": "~0.41.0",
+        "are-docs-informative": "^0.0.2",
+        "comment-parser": "1.4.1",
+        "debug": "^4.3.4",
+        "escape-string-regexp": "^4.0.0",
+        "esquery": "^1.5.0",
+        "is-builtin-module": "^3.2.1",
+        "semver": "^7.5.4",
+        "spdx-expression-parse": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0"
       }
     },
     "node_modules/eslint-plugin-jsdoc": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   "devDependencies": {
     "@stylistic/eslint-plugin-js": "^1.5.4",
     "eslint": "^8.56.0",
+    "eslint-config-tjw-jsdoc": "^1.0.5",
     "eslint-plugin-jsdoc": "^48.0.2",
     "eslint-plugin-markdown": "^3.0.1",
     "jsdoc": "^4.0.2",
@@ -85,8 +86,8 @@
     },
     "extends": [
       "eslint:recommended",
-      "plugin:jsdoc/recommended",
-      "plugin:markdown/recommended"
+      "plugin:markdown/recommended",
+      "tjw-jsdoc"
     ],
     "plugins": [
       "@stylistic/js"
@@ -96,8 +97,7 @@
         "error",
         2
       ],
-      "jsdoc/tag-lines": "off",
-      "jsdoc/check-property-names": "off"
+      "jsdoc/require-file-overview": "off"
     }
   }
 }

--- a/src/get/https.js
+++ b/src/get/https.js
@@ -1,0 +1,47 @@
+import fs from "node:fs";
+import https from "node:https";
+
+import progress from "cli-progress";
+
+/**
+ * Download from `url` to `outFile` file path.
+ * 
+ * @param {string} url - Download server
+ * @param {string} outFile - File path of downloaded content
+ * @returns {Promise<void>}
+ */
+export default async function getRequest(url, outFile) {
+
+  /**
+   * @type {number}
+   */
+  let chunks = 0;
+
+  const bar = new progress.SingleBar({}, progress.Presets.rect);
+  const writeStream = fs.createWriteStream(outFile);
+
+  return new Promise((resolve, reject) => {
+    https.get(url, function (response) {
+
+      bar.start(Number(response.headers["content-length"]), 0);
+
+      response.on("data", function (chunk) {
+        chunks += chunk.length;
+        bar.increment();
+        bar.update(chunks);
+      });
+
+      response.on("error", function (error) {
+        reject(error);
+      });
+
+      response.on("end", () => {
+        bar.stop();
+        resolve();
+      });
+
+      response.pipe(writeStream);
+
+    });
+  });
+}

--- a/src/get/https.js
+++ b/src/get/https.js
@@ -10,7 +10,7 @@ import progress from "cli-progress";
  * @param {string} outFile - File path of downloaded content
  * @returns {Promise<Buffer>}
  */
-export default async function getRequest(url) {
+export default async function request(url) {
 
   /**
    * Tracks the download progress. Minimum is 0 and maximum is the size of file.

--- a/src/get/https.js
+++ b/src/get/https.js
@@ -4,7 +4,7 @@ import https from "node:https";
 import progress from "cli-progress";
 
 /**
- * Download from `url` to `outFile` file path.
+ * Download from `url`.
  * 
  * @param {string} url - Download server
  * @returns {Promise<Buffer>} - Downloaded content

--- a/src/get/https.js
+++ b/src/get/https.js
@@ -1,4 +1,4 @@
-import fs from "node:fs";
+// import fs from "node:fs";
 import https from "node:https";
 
 import progress from "cli-progress";
@@ -7,8 +7,7 @@ import progress from "cli-progress";
  * Download from `url` to `outFile` file path.
  * 
  * @param {string} url - Download server
- * @param {string} outFile - File path of downloaded content
- * @returns {Promise<Buffer>}
+ * @returns {Promise<Buffer>} - Downloaded content
  */
 export default async function request(url) {
 
@@ -20,11 +19,10 @@ export default async function request(url) {
   let chunkSize = 0;
 
   const bar = new progress.SingleBar({}, progress.Presets.rect);
-  const writeStream = fs.createWriteStream(outFile);
 
   return new Promise((resolve, reject) => {
     https.get(url, function (response) {
-      
+
       /**
        * @type {Buffer}
        */
@@ -47,9 +45,6 @@ export default async function request(url) {
         bar.stop();
         resolve(responseBody);
       });
-
-      response.pipe(writeStream);
-
     });
   });
 }

--- a/src/get/https.js
+++ b/src/get/https.js
@@ -5,15 +5,18 @@ import progress from "cli-progress";
 
 /**
  * Download from `url`.
+ *
+ * @async
+ * @function
  * 
- * @param {string} url - Download server
- * @returns {Promise<Buffer>} - Downloaded content
+ * @param  {string}          url  - Download server
+ * @return {Promise<Buffer>}      - Downloaded content
  */
 export default async function request(url) {
 
   /**
    * Tracks the download progress. Minimum is 0 and maximum is the size of file.
-   * 
+   *
    * @type {number}
    */
   let chunkSize = 0;

--- a/src/get/https.js
+++ b/src/get/https.js
@@ -20,6 +20,7 @@ export default async function request(url) {
   let chunkSize = 0;
 
   const bar = new progress.SingleBar({}, progress.Presets.rect);
+  const writeStream = fs.createWriteStream(outFile);
 
   return new Promise((resolve, reject) => {
     https.get(url, function (response) {
@@ -30,8 +31,6 @@ export default async function request(url) {
       let responseBody = '';
       bar.start(Number(response.headers["content-length"]), 0);
       response.setEncoding('utf8');
-
-
 
       response.on("data", function (chunk) {
         chunkSize += chunk.length;

--- a/src/get/https.test.js
+++ b/src/get/https.test.js
@@ -50,4 +50,4 @@ describe("get https", function () {
     url = "";
     await expect(https(url, out)).rejects.toThrowError();
   });
-}, { timeout: Infinity });
+});

--- a/src/get/https.test.js
+++ b/src/get/https.test.js
@@ -1,5 +1,3 @@
-import fs from "node:fs";
-
 import { describe, expect, it } from "vitest";
 
 import request from "./https.js";
@@ -7,7 +5,6 @@ import request from "./https.js";
 describe("get https", function () {
 
   let url = "https://raw.githubusercontent.com/nwutils/nw-builder/main/src/util/osx.arm.versions.json"
-  let out = "./test/fixture/cache/content.json";
 
   it("downloads from specific url", async function () {
     const buffer = await request(url);

--- a/src/get/https.test.js
+++ b/src/get/https.test.js
@@ -2,7 +2,7 @@ import fs from "node:fs";
 
 import { describe, expect, it } from "vitest";
 
-import https from "./https.js";
+import request from "./https.js";
 
 describe("get https", function () {
 
@@ -10,7 +10,7 @@ describe("get https", function () {
   let out = "./test/fixture/cache/content.json";
 
   it("gets file from specific url", async function () {
-    await https(url, out);
+    await request(url, out);
     expect(fs.existsSync(out));
   }, Infinity);
 
@@ -48,6 +48,6 @@ describe("get https", function () {
 
   it("throws error on invalid url", async function () {
     url = "";
-    await expect(https(url, out)).rejects.toThrowError();
+    await expect(request(url, out)).rejects.toThrowError();
   });
 });

--- a/src/get/https.test.js
+++ b/src/get/https.test.js
@@ -12,7 +12,7 @@ describe("get https", function () {
   it("gets file from specific url", async function () {
     await https(url, out);
     expect(fs.existsSync(out));
-  }, 30);
+  }, 10000);
 
   it("gets correct file", async function () {
     const actualContents = JSON.parse(await fs.promises.readFile(out));

--- a/src/get/https.test.js
+++ b/src/get/https.test.js
@@ -6,50 +6,50 @@ import https from "./https.js";
 
 describe("get https", function () {
 
-    let url = "https://raw.githubusercontent.com/nwutils/nw-builder/main/src/util/osx.arm.versions.json"
+  let url = "https://raw.githubusercontent.com/nwutils/nw-builder/main/src/util/osx.arm.versions.json"
+  let out = "./test/fixture/cache/content.json";
+
+  it("gets file from specific url", async function () {
+    await https(url, out);
+    expect(fs.existsSync(out));
+  });
+
+  it("gets correct file", async function () {
+    const actualContents = JSON.parse(await fs.promises.readFile(out));
+    const expectedContents = {
+      "latest": "v0.75.0",
+      "stable": "v0.75.0",
+      "lts": "v0.75.0",
+      "versions": [
+        {
+          "version": "v0.75.0",
+          "date": "2023/04/15",
+          "files": ["osx-arm64"],
+          "flavors": ["normal", "sdk"],
+          "components": {
+            "node": "19.7.0",
+            "chromium": "112.0.5615.49"
+          }
+        },
+        {
+          "version": "v0.70.0",
+          "date": "2022/11/30",
+          "files": ["osx-arm64"],
+          "flavors": ["normal", "sdk"],
+          "components": {
+            "node": "19.0.0",
+            "chromium": "107.0.5304.88"
+          }
+        }
+      ]
+    };
+    expect(actualContents).toStrictEqual(expectedContents);
+  });
+
+  it("throws error on invalid url", async function () {
+    let url = "";
     let out = "./test/fixture/cache/content.json";
-
-    it("gets file from specific url", async function () {
-        await https(url, out);
-        expect(fs.existsSync(out));
-    });
-
-    it("gets correct file", async function () {
-        const actualContents = JSON.parse(await fs.promises.readFile(out));
-        const expectedContents = {
-            "latest": "v0.75.0",
-            "stable": "v0.75.0",
-            "lts": "v0.75.0",
-            "versions": [
-                {
-                    "version": "v0.75.0",
-                    "date": "2023/04/15",
-                    "files": ["osx-arm64"],
-                    "flavors": ["normal", "sdk"],
-                    "components": {
-                        "node": "19.7.0",
-                        "chromium": "112.0.5615.49"
-                    }
-                },
-                {
-                    "version": "v0.70.0",
-                    "date": "2022/11/30",
-                    "files": ["osx-arm64"],
-                    "flavors": ["normal", "sdk"],
-                    "components": {
-                        "node": "19.0.0",
-                        "chromium": "107.0.5304.88"
-                    }
-                }
-            ]
-        };
-        expect(actualContents).toStrictEqual(expectedContents);
-    });
-
-    it("throws error on invalid url", async function () {
-        let url = "";
-        let out = "./test/fixture/cache/content.json";
         
-        await expect(https(url, out)).rejects.toThrowError();
-    });
+    await expect(https(url, out)).rejects.toThrowError();
+  });
 });

--- a/src/get/https.test.js
+++ b/src/get/https.test.js
@@ -12,7 +12,7 @@ describe("get https", function () {
   it("gets file from specific url", async function () {
     await https(url, out);
     expect(fs.existsSync(out));
-  }, 10000);
+  }, Infinity);
 
   it("gets correct file", async function () {
     const actualContents = JSON.parse(await fs.promises.readFile(out));

--- a/src/get/https.test.js
+++ b/src/get/https.test.js
@@ -1,0 +1,55 @@
+import fs from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+import https from "./https.js";
+
+describe("get https", function () {
+
+    let url = "https://raw.githubusercontent.com/nwutils/nw-builder/main/src/util/osx.arm.versions.json"
+    let out = "./test/fixture/cache/content.json";
+
+    it("gets file from specific url", async function () {
+        await https(url, out);
+        expect(fs.existsSync(out));
+    });
+
+    it("gets correct file", async function () {
+        const actualContents = JSON.parse(await fs.promises.readFile(out));
+        const expectedContents = {
+            "latest": "v0.75.0",
+            "stable": "v0.75.0",
+            "lts": "v0.75.0",
+            "versions": [
+                {
+                    "version": "v0.75.0",
+                    "date": "2023/04/15",
+                    "files": ["osx-arm64"],
+                    "flavors": ["normal", "sdk"],
+                    "components": {
+                        "node": "19.7.0",
+                        "chromium": "112.0.5615.49"
+                    }
+                },
+                {
+                    "version": "v0.70.0",
+                    "date": "2022/11/30",
+                    "files": ["osx-arm64"],
+                    "flavors": ["normal", "sdk"],
+                    "components": {
+                        "node": "19.0.0",
+                        "chromium": "107.0.5304.88"
+                    }
+                }
+            ]
+        };
+        expect(actualContents).toStrictEqual(expectedContents);
+    });
+
+    it("throws error on invalid url", async function () {
+        let url = "";
+        let out = "./test/fixture/cache/content.json";
+        
+        await expect(https(url, out)).rejects.toThrowError();
+    });
+});

--- a/src/get/https.test.js
+++ b/src/get/https.test.js
@@ -9,45 +9,14 @@ describe("get https", function () {
   let url = "https://raw.githubusercontent.com/nwutils/nw-builder/main/src/util/osx.arm.versions.json"
   let out = "./test/fixture/cache/content.json";
 
-  it("gets file from specific url", async function () {
-    await request(url, out);
-    expect(fs.existsSync(out));
+  it("downloads from specific url", async function () {
+    const buffer = await request(url);
+    // Find a better way to assert this
+    expect(buffer).not.toBeUndefined();
   }, Infinity);
 
-  it("gets correct file", async function () {
-    const actualContents = JSON.parse(await fs.promises.readFile(out));
-    const expectedContents = {
-      "latest": "v0.75.0",
-      "stable": "v0.75.0",
-      "lts": "v0.75.0",
-      "versions": [
-        {
-          "version": "v0.75.0",
-          "date": "2023/04/15",
-          "files": ["osx-arm64"],
-          "flavors": ["normal", "sdk"],
-          "components": {
-            "node": "19.7.0",
-            "chromium": "112.0.5615.49"
-          }
-        },
-        {
-          "version": "v0.70.0",
-          "date": "2022/11/30",
-          "files": ["osx-arm64"],
-          "flavors": ["normal", "sdk"],
-          "components": {
-            "node": "19.0.0",
-            "chromium": "107.0.5304.88"
-          }
-        }
-      ]
-    };
-    expect(actualContents).toStrictEqual(expectedContents);
-  });
-
-  it("throws error on invalid url", async function () {
+  it("throws error if url is invalid", async function () {
     url = "";
-    await expect(request(url, out)).rejects.toThrowError();
+    await expect(request(url)).rejects.toThrowError();
   });
 });

--- a/src/get/https.test.js
+++ b/src/get/https.test.js
@@ -12,7 +12,7 @@ describe("get https", function () {
   it("gets file from specific url", async function () {
     await https(url, out);
     expect(fs.existsSync(out));
-  }, 10);
+  }, 30);
 
   it("gets correct file", async function () {
     const actualContents = JSON.parse(await fs.promises.readFile(out));

--- a/src/get/https.test.js
+++ b/src/get/https.test.js
@@ -12,7 +12,7 @@ describe("get https", function () {
   it("gets file from specific url", async function () {
     await https(url, out);
     expect(fs.existsSync(out));
-  });
+  }, 10);
 
   it("gets correct file", async function () {
     const actualContents = JSON.parse(await fs.promises.readFile(out));

--- a/src/get/https.test.js
+++ b/src/get/https.test.js
@@ -47,9 +47,7 @@ describe("get https", function () {
   });
 
   it("throws error on invalid url", async function () {
-    let url = "";
-    let out = "./test/fixture/cache/content.json";
-        
+    url = "";
     await expect(https(url, out)).rejects.toThrowError();
   });
-});
+}, { timeout: Infinity });


### PR DESCRIPTION
### Description of Changes

- Factor out https logic.
- Separate `fs` from `https` wrapper implementation.

Notes: Unzipping MacOS binaries on MacOS is failing with `End of Central Directory Record not found` error which is unrelated to this change.