### PR TITLE
feat(get): set `cacheDir` on another volume

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "axios": "^1.6.7",
         "cli-progress": "^3.12.0",
         "compressing": "^1.10.0",
+        "fs-extra": "^11.2.0",
         "glob": "^10.3.10",
         "node-gyp": "^10.0.1",
         "plist": "^3.1.0",
@@ -2487,6 +2488,19 @@
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
     },
+    "node_modules/fs-extra": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/fs-minipass": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.3.tgz",
@@ -3151,6 +3165,17 @@
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
       "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
       "dev": true
+    },
+    "node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
     },
     "node_modules/jszip": {
       "version": "3.10.1",
@@ -4968,6 +4993,14 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/uri-js": {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "axios": "^1.6.7",
     "cli-progress": "^3.12.0",
     "compressing": "^1.10.0",
+    "fs-extra": "^11.2.0",
     "glob": "^10.3.10",
     "node-gyp": "^10.0.1",
     "plist": "^3.1.0",

--- a/src/get.js
+++ b/src/get.js
@@ -212,7 +212,7 @@ const createSymlinks = async (options) => {
   let frameworksPath = path.resolve(process.cwd(), options.cacheDir, `nwjs${options.flavor === "sdk" ? "-sdk" : ""}-v${options.version}-${options.platform}-${options.arch}`, "nwjs.app", "Contents", "Frameworks", "nwjs Framework.framework")
   // Allow resolve cacheDir from another directory for prevent crash
   if (!fs.lstatSync(frameworksPath).isDirectory()) {
-      frameworksPath = path.resolve(options.cacheDir, `nwjs${options.flavor === "sdk" ? "-sdk" : ""}-v${options.version}-${options.platform}-${options.arch}`, "nwjs.app", "Contents", "Frameworks", "nwjs Framework.framework")
+    frameworksPath = path.resolve(options.cacheDir, `nwjs${options.flavor === "sdk" ? "-sdk" : ""}-v${options.version}-${options.platform}-${options.arch}`, "nwjs.app", "Contents", "Frameworks", "nwjs Framework.framework")
   }
   const symlinks = [
     path.join(frameworksPath, "Helpers"),

--- a/src/get.js
+++ b/src/get.js
@@ -285,7 +285,11 @@ const getNodeHeaders = async (options) => {
 }
 
 const createSymlinks = async (options) => {
-  const frameworksPath = path.join(process.cwd(), options.cacheDir, `nwjs${options.flavor === "sdk" ? "-sdk" : ""}-v${options.version}-${options.platform}-${options.arch}`, "nwjs.app", "Contents", "Frameworks", "nwjs Framework.framework");
+  let frameworksPath = path.resolve(process.cwd(), options.cacheDir, `nwjs${options.flavor === "sdk" ? "-sdk" : ""}-v${options.version}-${options.platform}-${options.arch}`, "nwjs.app", "Contents", "Frameworks", "nwjs Framework.framework")
+  // Allow resolve cacheDir from another directory for prevent crash
+  if (!fs.lstatSync(frameworksPath).isDirectory()) {
+      frameworksPath = path.resolve(options.cacheDir, `nwjs${options.flavor === "sdk" ? "-sdk" : ""}-v${options.version}-${options.platform}-${options.arch}`, "nwjs.app", "Contents", "Frameworks", "nwjs Framework.framework")
+  }
   const symlinks = [
     path.join(frameworksPath, "Helpers"),
     path.join(frameworksPath, "Libraries"),

--- a/src/get/decompress.js
+++ b/src/get/decompress.js
@@ -4,6 +4,7 @@ import stream from "node:stream";
 
 import tar from "tar";
 import yauzl from "yauzl-promise";
+import {ensureSymlink} from "fs-extra";
 
 /**
  * Decompresses a file at `filePath` to `cacheDir` directory.
@@ -32,19 +33,61 @@ export default async function decompress(filePath, cacheDir) {
  * @return {Promise<void>}
  */
 export async function unzip(zippedFile, cacheDir) {
+  await unzipInternal(zippedFile, cacheDir, false).then(() => {
+    unzipInternal(zippedFile, cacheDir, true);
+  })
+}
+
+/**
+ * Method for unzip with symlink in theoretical
+ *
+ * @async
+ * @function
+ * @param                  unzipSymlink
+ * @param  {string}        zippedFile    - file path to .zip file
+ * @param  {string}        cacheDir      - directory to unzip in
+ * @param  {boolean}       unzipSymlink  - Using or not symlink
+ * @return {Promise<void>}
+ */
+async function unzipInternal(zippedFile, cacheDir, unzipSymlink )  {
   const zip = await yauzl.open(zippedFile);
 
   let entry = await zip.readEntry();
 
   while (entry !== null) {
+    // console.log(entry)
     let entryPathAbs = path.join(cacheDir, entry.filename);
-
     // Create the directory beforehand to prevent `ENOENT: no such file or directory` errors.
-    await fs.promises.mkdir(path.dirname(entryPathAbs), { recursive: true });
-
+    await fs.promises.mkdir(path.dirname(entryPathAbs), {recursive: true});
     const readStream = await entry.openReadStream();
-    const writeStream = fs.createWriteStream(entryPathAbs);
-    await stream.promises.pipeline(readStream, writeStream);
+
+    try {
+      if (!unzipSymlink) {
+        // Regular method and silent error at this point
+        const writeStream = fs.createWriteStream(entryPathAbs);
+        await stream.promises.pipeline(readStream, writeStream);
+      } else {
+        // Need check before if file is a symlink or not at this point
+        const pathContent = await fs.promises.lstat(entryPathAbs);
+
+        if (pathContent.isSymbolicLink()) {
+          const chunks = [];
+          readStream.on('data', (chunk) => chunks.push(chunk));
+          await stream.promises.finished(readStream);
+          // need fetch value of current symlink here
+          const linkTarget = Buffer.concat(chunks).toString('utf8').trim();
+          await ensureSymlink(entryPathAbs, path.join(path.dirname(entryPathAbs), linkTarget));
+        }else{
+          // Regular method and silent error at this point
+          const writeStream = fs.createWriteStream(entryPathAbs);
+          await stream.promises.pipeline(readStream, writeStream);
+        }
+      }
+    } catch (error) {
+      if (unzipSymlink) {
+        console.error(error);
+      }
+    }
 
     entry = await zip.readEntry();
   }

--- a/src/util.js
+++ b/src/util.js
@@ -162,12 +162,11 @@ const replaceFfmpeg = async (platform, nwDir) => {
  *
  * @async
  * @function
- * 
+ *
  * @param  {object}            options         - glob file options
  * @param  {string | string[]} options.srcDir  - app src dir
  * @param  {boolean}           options.glob    - glob flag
  * @return {Promise<string[]>}                 - Returns array of file paths
- 
  */
 async function globFiles({
   srcDir,
@@ -449,7 +448,7 @@ export const validate = async (options, releaseInfo) => {
  *
  * @async
  * @function
- * 
+ *
  * @param  {"chromedriver"} type     - NW specific file or directory
  * @param  {object}         options  - nwbuild options
  * @return {string}                  - Path to chromedriver
@@ -470,7 +469,7 @@ async function getPath(type, options) {
 
 /**
  *
- * @param  {string}           filePath  - File path to check existence of 
+ * @param  {string}           filePath  - File path to check existence of
  * @return {Promise<boolean>}           `true` if exists, otherwise `false`
  */
 async function fileExists(filePath) {


### PR DESCRIPTION
### Description of Changes

- Use both absolute and relative paths for the cache directory.
-  Fixes the issue on MacOS related to the existence of a cache folder that is not present in the same current directory.
- Correctly unzips files in MacOs.

Notes: Resolves issued caused by cache is in a directory other than the current path.

Closes: #1017