### PR TITLE
chore(run): mark run mode as deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ nwbuild({
 
 ### Run Mode
 
+> Deprecation warning: From v4.6.0 onward, run mode is deprecated. This logic will be ported over to `nwjs/npm-installer` repo and removed in the next major release.
+
 ```javascript
 nwbuild({
   mode: "run",

--- a/src/run.js
+++ b/src/run.js
@@ -20,6 +20,8 @@ import util from "./util.js";
 /**
  * Run NW.js application.
  *
+ * @deprecated since v4.6.0. This logic will be ported over to `nwjs/npm-installer` repo and removed in the next major release (v5.0).
+ * 
  * @async
  * @function
  * 


### PR DESCRIPTION
### Description of Changes

- Mark run mode as deprecated

Notes: nw-builder needs to focus on building and packaging apps. Instead of maintaining a run mode, port this behaviour to nwjs/npm-installer and improve interop between the tools.
