### PR TITLE
chore(get): simplify symlink logic

### DIFF
--- a/src/get/decompress.js
+++ b/src/get/decompress.js
@@ -52,21 +52,23 @@ async function unzip(zippedFile, cacheDir) {
 
   while (entry !== null) {
     let entryPathAbs = path.join(cacheDir, entry.filename);
-    // Create the directory beforehand to prevent `ENOENT: no such file or directory` errors.
+    /* Create the directory beforehand to prevent `ENOENT: no such file or directory` errors. */
     await fs.promises.mkdir(path.dirname(entryPathAbs), { recursive: true });
-    // Pipe read to write stream
+    /* Check if entry is a symbolic link */
+    const isSymlink = ((modeFromEntry(entry) & 0o170000) === 0o120000);
     const readStream = await entry.openReadStream();
-    const writeStream = fs.createWriteStream(entryPathAbs);
-    await stream.promises.pipeline(readStream, writeStream);
-    // Get file mode
-    let fileMode = modeFromEntry(entry);
-    const isSymlink = ((fileMode & 0o170000) === 0o120000);
-
+    
     if (isSymlink) {
-      const buffer = await fs.promises.readFile(entryPathAbs);
-      const link = buffer.toString();
-      await fs.promises.rm(entryPathAbs);
-      await fs.promises.symlink(link, entryPathAbs);
+      const chunks = [];
+      /* Read stream into Array. */
+      readStream.on("data", (chunk) => chunks.push(chunk));
+      await stream.promises.finished(readStream);
+      const link = Buffer.concat(chunks).toString('utf8').trim();
+      await fs.promises.symlink(link, entryPathAbs)
+    } else {
+      // Pipe read to write stream
+      const writeStream = fs.createWriteStream(entryPathAbs);
+      await stream.promises.pipeline(readStream, writeStream);
     }
 
     // Read next entry


### PR DESCRIPTION
* Current implementation: write entry as file, check if entry is symlink, remove file and create symlink
* Improved implementation: check if entry is symlink, stream entry to buffer, extract link target and create symlink. Otherwise, stream entry to file.

Refs: #1030
