### PR TITLE
fix(get): copy ffmpeg to correct location on windows

### DIFF
--- a/src/get/index.js
+++ b/src/get/index.js
@@ -155,7 +155,7 @@ async function get(options) {
     if (options.platform === "linux") {
       ffmpegBinaryDest = path.resolve(nwDirPath, "lib", ffmpegFileName);
     } else if (options.platform === "win") {
-      // Extracted file is already in the correct path
+      ffmpegBinaryDest = path.resolve(nwDirPath, ffmpegFileName);
     } else if (options.platform === "osx") {
       ffmpegBinaryDest = path.resolve(
         nwDirPath,


### PR DESCRIPTION
* Windows FFmpeg copy was breaking because the destination path was never set