### PR TITLE
fix: pass manifest correctly when managedManifest is true

### DIFF
--- a/src/bld.js
+++ b/src/bld.js
@@ -177,7 +177,7 @@ async function bld({
     typeof managedManifest === "object" ||
     typeof managedManifest === "string"
   ) {
-    await manageManifest({ manifest, managedManifest, outDir, platform });
+    await manageManifest({ nwPkg: manifest, managedManifest, outDir, platform });
   }
 
   if (platform === "linux") {


### PR DESCRIPTION
- pass manifest correctly when managedManifest is true