### PR TITLE
feat(bld): add NSLocalNetworkUsageDescription option for MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ This object defines additional properties used for building for a specific platf
 | CFBundleVersion | `string` | The version of the build that identifies an iteration of the bundle. |
 | CFBundleShortVersionString | `string` | The release or version number of the bundle. |
 | NSHumanReadableCopyright | `string` | A human-readable copyright notice for the bundle. |
+| NSLocalNetworkUsageDescription | `string` | A human-readable description of why the application needs access to the local network. |
 
 
 ## Guides

--- a/src/bld.js
+++ b/src/bld.js
@@ -44,17 +44,18 @@ import setOsxConfig from './bld/osx.js';
 /**
  * References:
  * https://developer.apple.com/documentation/bundleresources/information_property_list
- * @typedef  {object} OsxRc                       OSX resource configuration options
- * @property {string} name                        The name of the application
- * @property {string} icon                        The path to the icon file. It should be a .icns file.
- * @property {string} LSApplicationCategoryType   The category that best describes your app for the App Store.
- * @property {string} CFBundleIdentifier          A unique identifier for a bundle usually in reverse DNS format.
- * @property {string} CFBundleName                A user-visible short name for the bundle.
- * @property {string} CFBundleDisplayName         The user-visible name for the bundle.
- * @property {string} CFBundleSpokenName          A replacement for the app name in text-to-speech operations.
- * @property {string} CFBundleVersion             The version of the build that identifies an iteration of the bundle.
- * @property {string} CFBundleShortVersionString  The release or version number of the bundle.
- * @property {string} NSHumanReadableCopyright    A human-readable copyright notice for the bundle.
+ * @typedef  {object} OsxRc                           OSX resource configuration options
+ * @property {string} name                            The name of the application
+ * @property {string} icon                            The path to the icon file. It should be a .icns file.
+ * @property {string} LSApplicationCategoryType       The category that best describes your app for the App Store.
+ * @property {string} CFBundleIdentifier              A unique identifier for a bundle usually in reverse DNS format.
+ * @property {string} CFBundleName                    A user-visible short name for the bundle.
+ * @property {string} CFBundleDisplayName             The user-visible name for the bundle.
+ * @property {string} CFBundleSpokenName              A replacement for the app name in text-to-speech operations.
+ * @property {string} CFBundleVersion                 The version of the build that identifies an iteration of the bundle.
+ * @property {string} CFBundleShortVersionString      The release or version number of the bundle.
+ * @property {string} NSHumanReadableCopyright        A human-readable copyright notice for the bundle.
+ * @property {string} NSLocalNetworkUsageDescription  A human-readable description of why the application needs access to the local network.
  */
 
 /**

--- a/src/bld/osx.js
+++ b/src/bld/osx.js
@@ -151,6 +151,7 @@ export default async function setOsxConfig({ app, outDir, releaseInfo }) {
     contentsInfoPlistJson.CFBundleVersion = app.CFBundleVersion;
     contentsInfoPlistJson.CFBundleShortVersionString = app.CFBundleShortVersionString;
     contentsInfoPlistJson.CFBundleExecutable = app.name;
+    contentsInfoPlistJson.NSLocalNetworkUsageDescription = app.NSLocalNetworkUsageDescription;
 
     /* Remove properties that were not updated by the user. */
     Object.keys(contentsInfoPlistJson).forEach((option) => {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -167,6 +167,8 @@ export interface OsxAppOptions {
     CFBundleShortVersionString?: string,
     /** A human-readable copyright notice for the bundle. */
     NSHumanReadableCopyright?: string,
+    /** A human-readable description of why the application needs access to the local network. */
+    NSLocalNetworkUsageDescription?: string,
 }
 
 /**

--- a/src/util.js
+++ b/src/util.js
@@ -263,6 +263,8 @@ export const parse = async (options, pkg) => {
       options.app.CFBundleShortVersionString ?? pkg.version;
     options.app.NSHumanReadableCopyright =
       options.app.NSHumanReadableCopyright ?? undefined;
+    options.app.NSLocalNetworkUsageDescription =
+      options.app.NSLocalNetworkUsageDescription ?? undefined;
   }
 
   return { ...options };

--- a/tests/specs/osx.test.js
+++ b/tests/specs/osx.test.js
@@ -80,7 +80,8 @@ describe.runIf(process.platform === 'darwin')('bld/setOsxConfig', async function
         CFBundleSpokenName: 'Demo',
         CFBundleVersion: '0.0.0',
         CFBundleShortVersionString: '0.0.0',
-        NSHumanReadableCopyright: 'Copyright (c) 2024 NW.js Utilities'
+        NSHumanReadableCopyright: 'Copyright (c) 2024 NW.js Utilities',
+        NSLocalNetworkUsageDescription: 'This test application needs to access the local network for testing purposes.'
       },
       outDir: outDir,
       releaseInfo: {
@@ -157,6 +158,7 @@ describe.runIf(process.platform === 'darwin')('bld/setOsxConfig', async function
     expect(ContentsInfoPlistJson.CFBundleVersion).toEqual('0.0.0');
     expect(ContentsInfoPlistJson.CFBundleShortVersionString).toEqual('0.0.0');
     expect(ContentsInfoPlistJson.CFBundleExecutable).toEqual('nwapp');
+    expect(ContentsInfoPlistJson.NSLocalNetworkUsageDescription).toEqual('This test application needs to access the local network for testing purposes.');
 
     const HelperAlertsAppJson = plist.parse(
       await fs.promises.readFile(


### PR DESCRIPTION
* Declare why an app needs to access the local network

Fixes: #1235

Refs: https://developer.apple.com/forums/thread/663858
Refs: https://developer.apple.com/documentation/bundleresources/information_property_list/nslocalnetworkusagedescription