### PR TITLE
fix(util): strip special and control characters from app.name

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -13,6 +13,7 @@ export default [
   jsdoc.configs['flat/recommended'],
   {
     rules: {
+      "no-control-regex": ["off"],
       "semi": ["error", "always"],
       "quotes": ["error", "single"],
     }

--- a/src/util.js
+++ b/src/util.js
@@ -202,7 +202,7 @@ export const parse = async (options, pkg) => {
 
   options.app = options.app ?? {};
   options.app.name = options.app.name ?? pkg.name;
-  options.app.name = options.app.name.replace(/[<>:"/\\|?*\u0000-\u001F]/g, "");
+  options.app.name = options.app.name.replace(/[<>:"/\\|?*\u0000-\u001F]/g, '');
   options.app.icon = options.app.icon ?? undefined;
 
   // TODO(#737): move this out

--- a/src/util.js
+++ b/src/util.js
@@ -202,6 +202,7 @@ export const parse = async (options, pkg) => {
 
   options.app = options.app ?? {};
   options.app.name = options.app.name ?? pkg.name;
+  options.app.name = options.app.name.replace(/[<>:"/\\|?*\u0000-\u001F]/g, "");
   options.app.icon = options.app.icon ?? undefined;
 
   // TODO(#737): move this out

--- a/src/util.js
+++ b/src/util.js
@@ -202,6 +202,7 @@ export const parse = async (options, pkg) => {
 
   options.app = options.app ?? {};
   options.app.name = options.app.name ?? pkg.name;
+  /* Remove special and control characters from app.name to mitigate potential path traversal. */
   options.app.name = options.app.name.replace(/[<>:"/\\|?*\u0000-\u001F]/g, '');
   options.app.icon = options.app.icon ?? undefined;
 


### PR DESCRIPTION
* This mitigates potential path traversal.

Fixes: #1258
