### PR TITLE
Don't overwrite all options previously specified when manifest is found (assign re-defined only)

### DIFF
--- a/src/bld/osx.js
+++ b/src/bld/osx.js
@@ -30,7 +30,8 @@ async function updateHelperPlist (plistPath, helperName, helperId, appCFBundleId
  * @param {string} options.releaseInfo  - Release information.
  * @returns {Promise<void>}             - Promise.
  */
-export default async function setOsxConfig({ app, outDir, releaseInfo }) {
+// TODO: implement "prepare" mode
+export default async function setOsxConfig({ app, outDir, releaseInfo, mode }) {
   if (process.platform === 'win32') {
     console.warn(
       'MacOS apps built on Windows platform do not preserve all file permissions. See #716',

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -8,7 +8,7 @@ export interface Options<P extends SupportedPlatform = SupportedPlatform> {
     /** String of space separated glob patterns which correspond to NW app code */
     srcDir?: "./" | string,
     /** Run or build application */
-    mode?: "build" | "get" | "run",
+    mode?: "build" | "get" | "run" | "prepare",
     /** NW runtime version */
     version?: "latest" | "stable" | string,
     /** NW runtime flavor */

--- a/src/index.js
+++ b/src/index.js
@@ -43,11 +43,15 @@ async function nwbuild(options) {
 
   try {
     // Parse options
-    options = await util.parse(options, manifest);
+    // options = await util.parse(options, manifest); // Preserve user input for now, assign manifest overwrites, only then parse
 
     manifest = await util.getNodeManifest({ srcDir: options.srcDir, glob: options.glob });
     if (typeof manifest?.nwbuild === 'object') {
-      options = manifest.nwbuild;
+      if(typeof manifest.nwbuild.app === 'object')
+        Object.assign(options.app, manifest.nwbuild.app);
+      let appOptions = options.app;
+      Object.assign(options, manifest.nwbuild);
+      options.app = appOptions;
     }
 
     options = await util.parse(options, manifest);

--- a/src/index.js
+++ b/src/index.js
@@ -44,6 +44,7 @@ async function nwbuild(options) {
   try {
     // Parse options
     // options = await util.parse(options, manifest); // Preserve user input for now, assign manifest overwrites, only then parse
+    var isPrepare = options.mode === 'prepare';
 
     manifest = await util.getNodeManifest({ srcDir: options.srcDir, glob: options.glob });
     if (typeof manifest?.nwbuild === 'object') {
@@ -53,6 +54,8 @@ async function nwbuild(options) {
       Object.assign(options, manifest.nwbuild);
       options.app = appOptions;
     }
+    if(isPrepare)
+      options.mode = 'prepare';
 
     options = await util.parse(options, manifest);
 
@@ -113,8 +116,9 @@ async function nwbuild(options) {
         glob: options.glob,
         argv: options.argv,
       });
-    } else if (options.mode === 'build') {
-      await bld({
+    } else if (options.mode === 'build' || options.mode === 'prepare') {
+      return await bld({
+        mode: options.mode,
         version: options.version,
         flavor: options.flavor,
         platform: options.platform,

--- a/src/util.js
+++ b/src/util.js
@@ -202,7 +202,8 @@ export const parse = async (options, pkg) => {
 
   options.app = options.app ?? {};
   options.app.name = options.app.name ?? pkg.name;
-  options.app.icon = options.app.icon ?? undefined;
+  options.app.name = options.app.name.replace(/[<>:"/\\|?*\u0000-\u001F]/g, "");
+  options.app.icon = options.app.icon ? path.resolve(options.app.icon) : undefined;
 
   // TODO(#737): move this out
   if (options.platform === 'linux') {
@@ -278,10 +279,9 @@ export const parse = async (options, pkg) => {
  * @throws {Error}                                         Throw error if options are invalid
  */
 export const validate = async (options, releaseInfo) => {
-  if (!['get', 'run', 'build'].includes(options.mode)) {
+  if (!['get', 'run', 'build', 'prepare'].includes(options.mode)) {
     throw new Error(
-      `Unknown mode ${options.mode}. Expected "get", "run" or "build".`,
-    );
+      `Unknown mode ${options.mode}. Expected "get", "run", "build" or "prepare".`);
   }
   if (typeof releaseInfo === 'undefined') {
     throw new Error(


### PR DESCRIPTION
<!-- Description of Changes -->

Changed behavior when finding a possible existing nwbuild manifest:  
Don't overwrite all options previously specified when manifest is found (assign re-defined only)

<!-- Notes: additional context on why this PR is being merged when it doesn't seem like it should -->

<!-- Fixes: # -->
Fixes: #1261
<!-- Closes: # -->
<!-- Refs: # -->

<!-- Note: Remove all markdown comments after creating the pull request -->
