### PR TITLE
Don't overwrite all options previously specified when manifest is found (assign re-defined only)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -43,11 +43,15 @@ async function nwbuild(options) {
 
   try {
     // Parse options
-    options = await util.parse(options, manifest);
+    // options = await util.parse(options, manifest); // Preserve user input for now, assign manifest overwrites, only then parse
 
     manifest = await util.getNodeManifest({ srcDir: options.srcDir, glob: options.glob });
     if (typeof manifest?.nwbuild === 'object') {
-      options = manifest.nwbuild;
+      if(typeof manifest.nwbuild.app === 'object')
+        Object.assign(options.app, manifest.nwbuild.app);
+      let appOptions = options.app;
+      Object.assign(options, manifest.nwbuild);
+      options.app = appOptions;
     }
 
     options = await util.parse(options, manifest);


### PR DESCRIPTION
Keep anything the user specified in the `options` object and only overwrite things found in any manifest (package.json) found.
- Assign `manifest.app` to `options.app`
- Assign `manifest` to `options`
- Restore `options.app`

<!-- Notes: additional context on why this PR is being merged when it doesn't seem like it should -->

<!-- Fixes: # -->
Fixes: #1261
<!-- Closes: # -->
<!-- Refs: # -->

<!-- Note: Remove all markdown comments after creating the pull request -->
