### PR TITLE
fix: pass options.manifestUrl to @nwutils/getter

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -99,6 +99,7 @@ async function nwbuild(options) {
       platform: options.platform,
       arch: options.arch,
       downloadUrl: options.downloadUrl,
+      manifestUrl: options.manifestUrl,
       cacheDir: options.cacheDir,
       cache: options.cache,
       ffmpeg: options.ffmpeg,


### PR DESCRIPTION
* pass manifestUrl to nw getter to prevent error `Cannot read properties of undefined (reading 'startsWith')` 

Fixes: #1521 
