### PR TITLE
fix(util): enforce options.nativeAddon to be boolean

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -103,6 +103,7 @@ async function nwbuild(options) {
       cacheDir: options.cacheDir,
       cache: options.cache,
       ffmpeg: options.ffmpeg,
+      // undefined but should be boolean...
       nativeAddon: options.nativeAddon,
       shaSum: options.shaSum,
       logLevel: options.logLevel,


### PR DESCRIPTION
Refs: https://github.com/ct-js/ct-js/pull/105#issuecomment-3984488048

grunt-nw-builder output
```shell
Error: Expected "options.nativeAddon" to be a boolean. Received: undefined
    at get (file:///home/runner/work/grunt-nw-builder/grunt-nw-builder/node_modules/@nwutils/getter/src/main.js:107:11)
    at async nwbuild (file:///home/runner/work/grunt-nw-builder/grunt-nw-builder/node_modules/nw-builder/src/index.js:96:5)
    at async Object.<anonymous> (/home/runner/work/grunt-nw-builder/grunt-nw-builder/tasks/nw.js:27:7)
Fatal error: Expected "options.nativeAddon" to be a boolean. Received: undefined
```