### PR TITLE
fix: do not replace but merge Node manifest options into default options

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -55,7 +55,7 @@ async function nwbuild(options) {
     util.log('debug', 'info', 'Get node manifest...');
     manifest = await util.getNodeManifest({ srcDir: options.srcDir, glob: options.glob });
     if (typeof manifest.json?.nwbuild === 'object') {
-      options = manifest.json.nwbuild;
+      options = { ...options, ...manifest.json.nwbuild };
     }
 
     util.log('info', options.logLevel, 'Parse final options using node manifest');


### PR DESCRIPTION
* Overrides options correctly if the node manifest is present.

Currently, if the node manifest is provided via `package.json`, all of the default options get blown away due to this mutation:

https://github.com/nwutils/nw-builder/blob/becde28fadd6c5dcd8f2d778a5d94ff47a70d9c9/src/index.js#L58

This change applies the manifest options as an override on top of the existing options.
