### PR TITLE
fix(bld): remove MacOS Plugin Helper renaming logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "eslint": "^10.2.0",
         "eslint-plugin-jsdoc": "^62.9.0",
         "globals": "^17.5.0",
-        "nw": "^0.110.1",
+        "nw": "^0.111.0",
         "selenium-webdriver": "^4.43.0",
         "vitest": "^4.0.14"
       }
@@ -1475,9 +1475,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2476,9 +2476,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3272,17 +3272,17 @@
       }
     },
     "node_modules/nw": {
-      "version": "0.110.1",
-      "resolved": "https://registry.npmjs.org/nw/-/nw-0.110.1.tgz",
-      "integrity": "sha512-E2tqLnWe/YGCR+cjuWvND2GnZu6OCB+Afh8WY76zaLxG5ee96tHuIEXmAKU11easYRJz9Pa4RqMNh+OyyVHoqQ==",
+      "version": "0.111.0",
+      "resolved": "https://registry.npmjs.org/nw/-/nw-0.111.0.tgz",
+      "integrity": "sha512-nd5pvZPzwbxwAb5yQvX8oqC1ykgOh/vPTZQHHJQY5EVYug2dQ8ujwxzRG26QizoABItzPJxaX5oJ3IcKvbuaMg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "axios": "^1.13.6",
+        "axios": "^1.15.2",
         "commander": "^14.0.3",
         "semver": "^7.7.4",
-        "tar": "^7.5.11",
+        "tar": "^7.5.13",
         "yauzl-promise": "^4.0.0"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "eslint": "^10.2.0",
     "eslint-plugin-jsdoc": "^62.9.0",
     "globals": "^17.5.0",
-    "nw": "^0.110.1",
+    "nw": "^0.111.0",
     "selenium-webdriver": "^4.43.0",
     "vitest": "^4.0.14"
   },

--- a/src/bld/osx.js
+++ b/src/bld/osx.js
@@ -77,7 +77,6 @@ export default async function setOsxConfig({ app, outDir, releaseInfo }) {
     const helperApps = [
       { name: 'nwjs Helper (Alerts).app', id: 'helper.alert' },
       { name: 'nwjs Helper (GPU).app', id: 'helper.gpu' },
-      { name: 'nwjs Helper (Plugin).app', id: 'helper.plugin' },
       { name: 'nwjs Helper (Renderer).app', id: 'helper.renderer' },
       { name: 'nwjs Helper.app', id: 'helper' },
     ];

--- a/tests/specs/osx.test.js
+++ b/tests/specs/osx.test.js
@@ -39,14 +39,6 @@ describe.runIf(process.platform === 'darwin')('bld/setOsxConfig', async function
     chromiumVersion,
     'Helpers',
     'Demo Helper (GPU).app');
-  const helperPluginPath = path.join(appPath,
-    'Contents',
-    'Frameworks',
-    'nwjs Framework.framework',
-    'Versions',
-    chromiumVersion,
-    'Helpers',
-    'Demo Helper (Plugin).app');
   const helperRendererPath = path.join(appPath,
     'Contents',
     'Frameworks',
@@ -102,9 +94,6 @@ describe.runIf(process.platform === 'darwin')('bld/setOsxConfig', async function
     const helperGPUPathExists = await util.fileExists(helperGPUPath);
     expect(helperGPUPathExists).toEqual(true);
 
-    const helperPluginPathExists = await util.fileExists(helperPluginPath);
-    expect(helperPluginPathExists).toEqual(true);
-
     const helperRendererPathExists = await util.fileExists(helperRendererPath);
     expect(helperRendererPathExists).toEqual(true);
 
@@ -124,10 +113,6 @@ describe.runIf(process.platform === 'darwin')('bld/setOsxConfig', async function
     const helperGPUExePath = path.join(helperGPUPath, 'Contents', 'MacOS', 'Demo Helper (GPU)');
     const helperGPUExePathExists = await util.fileExists(helperGPUExePath);
     expect(helperGPUExePathExists).toEqual(true);
-
-    const helperPluginExePath = path.join(helperPluginPath, 'Contents', 'MacOS', 'Demo Helper (Plugin)');
-    const helperPluginExePathExists = await util.fileExists(helperPluginExePath);
-    expect(helperPluginExePathExists).toEqual(true);
 
     const helperRendererExePath = path.join(helperRendererPath, 'Contents', 'MacOS', 'Demo Helper (Renderer)');
     const helperRendererExePathExists = await util.fileExists(helperRendererExePath);
@@ -191,22 +176,6 @@ describe.runIf(process.platform === 'darwin')('bld/setOsxConfig', async function
     expect(HelperGpuAppJson.CFBundleName).toEqual('Demo Helper (GPU)');
     expect(HelperGpuAppJson.CFBundleIdentifier).toEqual('io.nwutils.demo.helper.gpu');
     expect(HelperGpuAppJson.CFBundleExecutable).toEqual('Demo Helper (GPU)');
-
-    const HelperPluginAppJson = plist.parse(
-      await fs.promises.readFile(
-        path.resolve(
-          helperPluginPath,
-          'Contents',
-          'Info.plist'
-        ),
-        'utf-8'
-      )
-    );
-
-    expect(HelperPluginAppJson.CFBundleDisplayName).toEqual('Demo Helper (Plugin)');
-    expect(HelperPluginAppJson.CFBundleName).toEqual('Demo Helper (Plugin)');
-    expect(HelperPluginAppJson.CFBundleIdentifier).toEqual('io.nwutils.demo.helper.plugin');
-    expect(HelperPluginAppJson.CFBundleExecutable).toEqual('Demo Helper (Plugin)');
 
     const HelperRendererAppJson = plist.parse(
       await fs.promises.readFile(


### PR DESCRIPTION
Note: MacOS Plugin Helper is removed in NW.js v0.111.0 (Chromium M148)