### PR TITLE
feat(v3): add osxarm64 (Apple Silicon) platform support

### DIFF
--- a/lib/Version.cjs
+++ b/lib/Version.cjs
@@ -39,6 +39,7 @@ module.exports = function Version(args) {
     };
   } else {
     var fixPlatformName = function (platform) {
+      if (platform === "osxarm64") return "osx-arm64";
       return platform.replace("32", "-ia32").replace("64", "-x64");
     };
 

--- a/lib/index.cjs
+++ b/lib/index.cjs
@@ -25,6 +25,16 @@ const {
   validate,
 } = require("../dist/index.cjs");
 
+function parsePlatformArch(os) {
+  if (os === "osxarm64") {
+    return { platform: "osx", arch: "arm64" };
+  }
+  return {
+    platform: os.slice(0, os.length - 2),
+    arch: "x" + os.slice(os.length - 2),
+  };
+}
+
 class NwBuilder {
   constructor(options) {
     this.init(options).then(() => {
@@ -65,12 +75,7 @@ class NwBuilder {
 
       options = parse(options, manifest);
 
-      let platform = options.currentPlatform.slice(
-        0,
-        options.currentPlatform.length - 2,
-      );
-      let arch =
-        "x" + options.currentPlatform.slice(options.currentPlatform.length - 2);
+      let { platform, arch } = parsePlatformArch(options.currentPlatform);
 
       getReleaseInfo(
         options.version,
@@ -235,8 +240,7 @@ class NwBuilder {
       await fs.promises.mkdir(options.cacheDir, { recursive: true });
     }
     for await (const os of options.platforms) {
-      const platform = os.slice(0, os.length - 2);
-      const arch = "x" + os.slice(os.length - 2);
+      const { platform, arch } = parsePlatformArch(os);
       await get({
         version: options.version,
         flavor: options.flavor,
@@ -354,8 +358,7 @@ class NwBuilder {
 
   async copyNwjs() {
     for await (const os of this.options.platforms) {
-      const platform = os.slice(0, os.length - 2);
-      const arch = "x" + os.slice(os.length - 2);
+      const { platform, arch } = parsePlatformArch(os);
 
       await fs.promises.rm(path.resolve(this.options.buildDir, this.options.appName, os), {
         recursive: true,
@@ -492,7 +495,7 @@ class NwBuilder {
         self._files.forEach(function (file) {
           var dest;
 
-          if (name == "osx32" || name === "osx64") {
+          if (name == "osx32" || name === "osx64" || name === "osxarm64") {
             dest = path.resolve(
               self.getResourcesDirectoryPath(platform),
               "app.nw",
@@ -522,7 +525,7 @@ class NwBuilder {
             self,
           ),
         );
-      } else if (name == "osx32" || name == "osx64") {
+      } else if (name == "osx32" || name == "osx64" || name == "osxarm64") {
         // zip just copy the app.nw
         copyPromises.push(
           Utils.copyFile(
@@ -588,7 +591,7 @@ class NwBuilder {
       allDone = [];
 
     this._forEachPlatform(async function (name, platform) {
-      if (["osx32", "osx64"].indexOf(name) < 0) return;
+      if (["osx32", "osx64", "osxarm64"].indexOf(name) < 0) return;
 
       var executableName = self.getExecutableName(name);
 
@@ -599,7 +602,7 @@ class NwBuilder {
 
       // Let's first handle the mac icon
       if (self.options.macIcns) {
-        if (semver.satisfies(self._version.version, "<=0.12.3")) {
+        if (self._version && semver.satisfies(self._version.version, "<=0.12.3")) {
           allDone.push(
             Utils.copyFile(
               self.options.macIcns,
@@ -753,12 +756,7 @@ class NwBuilder {
   async runApp() {
     const options = this.options;
 
-    let platform = options.currentPlatform.slice(
-      0,
-      options.currentPlatform.length - 2,
-    );
-    let arch =
-      "x" + options.currentPlatform.slice(options.currentPlatform.length - 2);
+    let { platform, arch } = parsePlatformArch(options.currentPlatform);
 
     await run({
       version: options.version,

--- a/lib/versions.cjs
+++ b/lib/versions.cjs
@@ -113,7 +113,8 @@ function getManifest(manifestUrl) {
 function getVersionsFromManifest(downloadUrl, manifestUrl) {
   var mapFilesToPlatforms = function (files) {
     return files.map(function (file) {
-      // convert win-x64 to win64, linux-ia32 to linux 32, etc.
+      if (file === "osx-arm64") return "osxarm64";
+      // convert win-x64 to win64, linux-ia32 to linux32, etc.
       return file.replace(/-(x|ia)/, "");
     });
   };

--- a/src/constants/Platform.js
+++ b/src/constants/Platform.js
@@ -7,6 +7,7 @@ const Platform = {
   NIX_64: "linux64",
   OSX_32: "osx32",
   OSX_64: "osx64",
+  OSX_ARM64: "osxarm64",
   WIN_32: "win32",
   WIN_64: "win64",
 };

--- a/src/constants/Platforms.js
+++ b/src/constants/Platforms.js
@@ -108,6 +108,21 @@ const Platforms = {
     },
     versionNameTemplate: "v${ version }/${ name }-v${ version }-osx-x64.zip",
   },
+  osxarm64: {
+    needsZip: false,
+    getRunnable: function (version) {
+      if (semver.satisfies(version, ">=0.12.0 || ~0.12.0-alpha")) {
+        return "nwjs.app/Contents/MacOS/nwjs";
+      } else {
+        return "node-webkit.app/Contents/MacOS/node-webkit";
+      }
+    },
+    files: {
+      "<0.12.0-alpha": ["node-webkit.app"],
+      ">=0.12.0 || ~0.12.0-alpha": ["nwjs.app"],
+    },
+    versionNameTemplate: "v${ version }/${ name }-v${ version }-osx-arm64.zip",
+  },
   linux32: {
     needsZip: true,
     chmod: "0755",

--- a/src/utilities/detectCurrentPlatform.js
+++ b/src/utilities/detectCurrentPlatform.js
@@ -7,6 +7,7 @@ import Platform from "../constants/Platform.js";
 const detectCurrentPlatform = (process) => {
   switch (process.platform) {
     case "darwin":
+      if (process.arch === "arm64") return Platform.OSX_ARM64;
       return process.arch === "x64" ? Platform.OSX_64 : Platform.OSX_32;
 
     case "win32":

--- a/test/unit/detectCurrentPlatform.js
+++ b/test/unit/detectCurrentPlatform.js
@@ -23,6 +23,15 @@ describe("detectCurrentPlatform", () => {
     strictEqual(detectCurrentPlatform(process), Platform.OSX_64);
   });
 
+  it("for OSX ARM64 (Apple Silicon) platform", () => {
+    const process = {
+      platform: "darwin",
+      arch: "arm64",
+    };
+
+    strictEqual(detectCurrentPlatform(process), Platform.OSX_ARM64);
+  });
+
   it("for Linux 32 platform", () => {
     const process = {
       platform: "linux",


### PR DESCRIPTION
## Summary

The legacy `NwBuilder` class (v3 API) does not support building for macOS Apple Silicon (arm64). NW.js has shipped arm64 macOS builds since ~v0.64, and the newer `get()` API already accepts `arch: "arm64"` — but the v3 `NwBuilder` class never wired this through.

The root cause is that arch parsing is hardcoded as `"x" + platformName.slice(-2)` throughout the codebase, which produces `"x64"` for any platform name ending in `64`. For `osxarm64`, this gives `platform = "osxarm"` and `arch = "x64"` — wrong on both counts.

### Changes

- **`src/constants/Platform.js`** — Add `OSX_ARM64: "osxarm64"` to the Platform enum
- **`src/constants/Platforms.js`** — Add `osxarm64` platform definition with correct `versionNameTemplate` (`osx-arm64.zip`)
- **`src/utilities/detectCurrentPlatform.js`** — Return `OSX_ARM64` when `process.arch === "arm64"` on Darwin
- **`lib/index.cjs`** — Introduce `parsePlatformArch()` helper to replace fragile slice patterns in `downloadNwjs()`, `copyNwjs()`, `init()`, and `runApp()`. Add `osxarm64` to all Mac platform checks (`handleMacApp`, `mergeAppFiles`). Guard against undefined `_version` in `handleMacApp`.
- **`lib/Version.cjs`** — Handle `osxarm64` → `osx-arm64` in `fixPlatformName()`
- **`lib/versions.cjs`** — Map `osx-arm64` from NW.js manifest to `osxarm64` in `mapFilesToPlatforms()`
- **`test/unit/detectCurrentPlatform.js`** — Add unit test for ARM64 platform detection

### Usage

```js
const nw = new NwBuilder({
  files: ['./src/**', './package.json'],
  platforms: ['osxarm64'],
  version: '0.86.0',
  flavor: 'sdk',
});
nw.build();
```

Or via CLI: `--platforms=osxarm64`

### Tested

Built and ran a full NW.js application (Popcorn Time 0.5.1) on an Apple Silicon Mac. Binary confirmed as `Mach-O 64-bit executable arm64`, running natively (not under Rosetta).

## Test plan

- [x] Existing unit tests pass (`node --test test/unit/detectCurrentPlatform.js` — 7/7)
- [x] New ARM64 test case passes
- [x] Full build + run verified on M-series Mac