### PR TITLE
Fixes glob-enabled relative path bug

### DIFF
--- a/src/bld.js
+++ b/src/bld.js
@@ -151,7 +151,7 @@ async function bld({
         file,
         path.resolve(
           nwProjectDir,
-          file,
+          (file.substring(0, 3) == '..' + path.sep ? '.' + path.sep + file.substring(file.indexOf(path.sep,3)) : file),
         ),
         { recursive: true, force: true },
       );


### PR DESCRIPTION
* Fixes an issue with how relative paths are resolved to create the nwProjectDir upon building when using globs. Specifically when traveling up the folder structure.

Fixes: #1612