### PR TITLE
fix(run): sanitize child_process call

### DIFF
--- a/packages/runner/src/main.js
+++ b/packages/runner/src/main.js
@@ -76,11 +76,16 @@ async function run({
     throw new Error("Resolved executable path escapes cacheDir");
   }
 
+  if (!Array.isArray(argv) || !argv.every((arg) => typeof arg === "string")) {
+    throw new Error("Invalid argv: expected an array of strings");
+  }
+
   /**
    * @type {child_process.ChildProcess | null}
    */
   let nwProcess = child_process.spawn(nwExe, [...[srcDir], ...argv], {
     stdio: "inherit",
+    shell: false,
   });
 
   nwProcess.on("close", () => {


### PR DESCRIPTION
## Summary
Harden input handling in `packages/runner/src/main.js` (flagged by semgrep).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | javascript.lang.security.detect-child-process.detect-child-process |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `javascript.lang.security.detect-child-process.detect-child-process` |
| **File** | `packages/runner/src/main.js:82` |
| **Assessment** | Defensive hardening |

**Description**: Detected calls to child_process from a function argument `{
  version,
  flavor,
  platform,
  arch,
  srcDir,
  cacheDir,
  argv,
}`. This could lead to a command injection if the input is user controllable. Try to avoid calls to child_process, and if it is needed ensure user input is correctly sanitized or sandboxed. 

## Threat Model Context

This is a private Node.js application (not published to npm). Vulnerabilities affect this application's own runtime only.

## Changes
- `packages/runner/src/main.js`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*

<!-- orbis-meta: rule=javascript.lang.security.detect-child-process.detect-child-process scanner=semgrep -->
